### PR TITLE
fix: hide disclosure of non elec docs when small claim in dq (CMC-1589)

### DIFF
--- a/ccd-definition/CaseEventToFields/ClaimantResponse.json
+++ b/ccd-definition/CaseEventToFields/ClaimantResponse.json
@@ -100,7 +100,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "OPTIONAL",
     "PageID": "DisclosureOfNonElectronicDocuments",
-    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicant1ProceedWithClaim = \"Yes\"",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicant1ProceedWithClaim = \"Yes\" AND allocatedTrack !=\"SMALL_CLAIM\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/ccd-definition/CaseEventToFields/DefendantResponse.json
+++ b/ccd-definition/CaseEventToFields/DefendantResponse.json
@@ -133,7 +133,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "OPTIONAL",
     "PageID": "DisclosureOfNonElectronicDocuments",
-    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\"",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND allocatedTrack !=\"SMALL_CLAIM\"",
     "ShowSummaryChangeOption": "Y"
   },
   {


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1589

### Change description ###

Small claims show hide condition was removed in CMC-1160. Added back.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
