### PR TITLE
fix: empty check for pba accounts boolean field (CMC-1323)

### DIFF
--- a/ccd-definition/CaseEventToFields/CreateClaim.json
+++ b/ccd-definition/CaseEventToFields/CreateClaim.json
@@ -373,7 +373,7 @@
     "PageDisplayOrder": 18,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "applicantSolicitor1PbaAccountsIsEmpty = \"No\""
+    "FieldShowCondition": "applicantSolicitor1PbaAccountsIsEmpty = \"No\" OR applicantSolicitor1PbaAccountsIsEmpty = \"\""
   },
   {
     "LiveFrom": "01/01/2017",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1323

### Change description ###

Add empty check for boolean field

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
