### PR TITLE
fix: adding validation to document upload for litigation friend event (CMC-1596)

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
+++ b/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
@@ -86,7 +86,7 @@
     "ID": "RespondentSolicitor1Organisation",
     "CaseEventID": "ADD_DEFENDANT_LITIGATION_FRIEND",
     "CaseFieldID": "respondent1LitigationFriend",
-    "ListElementCode": "certificateOfSuitability",
+    "ListElementCode": "certificateOfSuitability.document",
     "FieldDisplayOrder": 10,
     "DisplayContext": "MANDATORY"
   }

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -25,7 +25,7 @@
     "ID": "LitigationFriend",
     "ListElementCode": "certificateOfSuitability",
     "FieldType": "Collection",
-    "FieldTypeParameter": "Document",
+    "FieldTypeParameter": "DocumentOrImageWithRegex",
     "ElementLabel": "Upload the certificate of suitability",
     "SecurityClassification": "Public",
     "Min": 1

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -14,7 +14,7 @@ module.exports = {
         }
       },
       litigantInFriendAddress: `#${partyType}LitigationFriend_primaryAddress_primaryAddress`,
-      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability_value`
+      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability`
     };
   },
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1596

### Change description ###
- added regex validation to certificate of suitability document by making it a ```DocumentOrImageWithRegex```
- corrected e2e test

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
