### PR TITLE
fix : use original certificateOfSuitability field (CMC-1596) (4/5)

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
+++ b/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
@@ -86,7 +86,7 @@
     "ID": "RespondentSolicitor1Organisation",
     "CaseEventID": "ADD_DEFENDANT_LITIGATION_FRIEND",
     "CaseFieldID": "respondent1LitigationFriend",
-    "ListElementCode": "certificateOfSuitability.document",
+    "ListElementCode": "certificateOfSuitabilityNew.document",
     "FieldDisplayOrder": 10,
     "DisplayContext": "MANDATORY"
   }

--- a/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
+++ b/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
@@ -76,7 +76,7 @@
     "ID": "RespondentSolicitor1Organisation",
     "CaseEventID": "ADD_DEFENDANT_LITIGATION_FRIEND",
     "CaseFieldID": "respondent1LitigationFriend",
-    "ListElementCode": "certificateOfSuitabilityNew.document",
+    "ListElementCode": "certificateOfSuitability.document",
     "FieldDisplayOrder": 10,
     "DisplayContext": "MANDATORY"
   }

--- a/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
+++ b/ccd-definition/CaseEventToComplexTypes/AddDefendantLitigationFriend.json
@@ -86,7 +86,7 @@
     "ID": "RespondentSolicitor1Organisation",
     "CaseEventID": "ADD_DEFENDANT_LITIGATION_FRIEND",
     "CaseFieldID": "respondent1LitigationFriend",
-    "ListElementCode": "certificateOfSuitability",
+    "ListElementCode": "certificateOfSuitability.document",
     "FieldDisplayOrder": 10,
     "DisplayContext": "MANDATORY"
   }

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -30,7 +30,8 @@
     "SecurityClassification": "Public",
     "Min": 1
   },
-  {"ID": "LitigationFriend",
+  {
+    "ID": "LitigationFriend",
     "ListElementCode": "certificateOfSuitabilityNew",
     "FieldType": "Collection",
     "FieldTypeParameter": "DocumentOrImageWithRegex",

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -25,9 +25,16 @@
     "ID": "LitigationFriend",
     "ListElementCode": "certificateOfSuitability",
     "FieldType": "Collection",
-    "FieldTypeParameter": "DocumentOrImageWithRegex",
+    "FieldTypeParameter": "Document",
     "ElementLabel": "Upload the certificate of suitability",
     "SecurityClassification": "Public",
     "Min": 1
-  }
+  },
+  {"ID": "LitigationFriend",
+    "ListElementCode": "certificateOfSuitabilityNew",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "DocumentOrImageWithRegex",
+    "ElementLabel": "Upload the certificate of suitability",
+    "SecurityClassification": "Public",
+    "Min": 1}
 ]

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -25,7 +25,7 @@
     "ID": "LitigationFriend",
     "ListElementCode": "certificateOfSuitability",
     "FieldType": "Collection",
-    "FieldTypeParameter": "Document",
+    "FieldTypeParameter": "DocumentOrImageWithRegex",
     "ElementLabel": "Upload the certificate of suitability",
     "SecurityClassification": "Public",
     "Min": 1

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -23,19 +23,11 @@
   },
   {
     "ID": "LitigationFriend",
-    "ListElementCode": "certificateOfSuitability",
-    "FieldType": "Collection",
-    "FieldTypeParameter": "Document",
-    "ElementLabel": "Upload the certificate of suitability",
-    "SecurityClassification": "Public",
-    "Min": 1
-  },
-  {
-    "ID": "LitigationFriend",
     "ListElementCode": "certificateOfSuitabilityNew",
     "FieldType": "Collection",
     "FieldTypeParameter": "DocumentOrImageWithRegex",
     "ElementLabel": "Upload the certificate of suitability",
     "SecurityClassification": "Public",
-    "Min": 1}
+    "Min": 1
+  }
 ]

--- a/ccd-definition/ComplexTypes/LitigationFriend.json
+++ b/ccd-definition/ComplexTypes/LitigationFriend.json
@@ -23,7 +23,7 @@
   },
   {
     "ID": "LitigationFriend",
-    "ListElementCode": "certificateOfSuitabilityNew",
+    "ListElementCode": "certificateOfSuitability",
     "FieldType": "Collection",
     "FieldTypeParameter": "DocumentOrImageWithRegex",
     "ElementLabel": "Upload the certificate of suitability",

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -14,7 +14,7 @@ module.exports = {
         }
       },
       litigantInFriendAddress: `#${partyType}LitigationFriend_primaryAddress_primaryAddress`,
-      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability`
+      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability_0_document`
     };
   },
 

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -14,7 +14,7 @@ module.exports = {
         }
       },
       litigantInFriendAddress: `#${partyType}LitigationFriend_primaryAddress_primaryAddress`,
-      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitabilityNew_0_document`
+      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability_0_document`
     };
   },
 

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -14,7 +14,7 @@ module.exports = {
         }
       },
       litigantInFriendAddress: `#${partyType}LitigationFriend_primaryAddress_primaryAddress`,
-      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability_0_document`
+      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitabilityNew_0_document`
     };
   },
 

--- a/e2e/fragments/litigationFriend.js
+++ b/e2e/fragments/litigationFriend.js
@@ -14,7 +14,7 @@ module.exports = {
         }
       },
       litigantInFriendAddress: `#${partyType}LitigationFriend_primaryAddress_primaryAddress`,
-      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability_value`
+      certificateOfSuitability: `#${partyType}LitigationFriend_certificateOfSuitability`
     };
   },
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1596

### Change description ###
- using the original `certificateOfSuitability` field, removing the `certificateOfSuitabilityNew` field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
