### PR TITLE
fix: allow for more readable test logging (CMC-1486)

### DIFF
--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -4,7 +4,7 @@ const deepEqualInAnyOrder = require('deep-equal-in-any-order');
 const chai = require('chai');
 
 chai.use(deepEqualInAnyOrder);
-
+chai.config.truncateThreshold = 0;
 const {expect, assert} = chai;
 
 const {waitForFinishedBusinessProcess, assignCaseToDefendant} = require('../api/testingSupport');


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1486

### Change description ###

Small change to the chai config to allow for more readable test logging. 

Example (before):
Running ````assert.deepEqual(responseBody.data, 'test')````

````
1) CCD API tests @api-tests
       Create claim:
     AssertionError: expected { Object (solicitorReferences) } to deeply equal 'test'
````
(After the change):

````
1) CCD API tests @api-tests
       Create claim:
AssertionError: expected { solicitorReferences: 
   { applicantSolicitor1Reference: 'Applicant reference',
     respondentSolicitor1Reference: 'Respondent reference' } } to deeply equal 'test'

````


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
