### PR TITLE
build: excluded -nonprod.json files from definition on all envs

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -91,7 +91,7 @@ withPipeline(type, product, component) {
     sh """
       eval \$(./bin/variables/load-preview-environment-variables.sh ${CHANGE_ID})
       ./bin/add-roles.sh
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
       ./bin/import-bpmn-diagram.sh .
     """
@@ -119,7 +119,7 @@ withPipeline(type, product, component) {
     sh """
       eval \$(./bin/variables/load-staging-environment-variables.sh)
       ./bin/add-roles.sh
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
       ./bin/import-bpmn-diagram.sh .
     """

--- a/bin/build-release-ccd-definition.sh
+++ b/bin/build-release-ccd-definition.sh
@@ -3,13 +3,14 @@
 set -eu
 
 environment=${1:-prod}
+excludeNonProdFiles=${2:-true}
 
 if [[ ${environment} != "prod" && ${environment} != "staging" && ${environment} != "aat" && ${environment} != "demo" ]]; then
   echo "Environment '${environment}' is not supported!"
   exit 1
 fi
 
-if [ ${environment} == "prod" ]; then
+if [ ${excludeNonProdFiles} == true ]; then
   excludedFilenamePatterns="-e UserProfile.json,*-nonprod.json"
 else
   excludedFilenamePatterns="-e UserProfile.json"


### PR DESCRIPTION
### Change description ###

All `-nonprod.json` files are now excluded on all environments by default. This is to ensure that we deploy and test production definition.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
