### PR TITLE
fix: Add authentication to pull-latest-release-asset.sh (CMC-1688)

### DIFF
--- a/bin/pull-latest-release-asset.sh
+++ b/bin/pull-latest-release-asset.sh
@@ -3,13 +3,26 @@
 repoName=$1
 assetName=$2
 
-latestAssetId=$(curl https://api.github.com/repos/hmcts/${repoName}/releases/latest \
-  | docker run --rm --interactive stedolan/jq ".assets[] | select(.name==\"${assetName}\") | .id")
+retries=0
+until [ -f "$assetName" ]
+do
+  latestAssetId=$(curl https://api.github.com/repos/hmcts/${repoName}/releases/latest \
+   | docker run --rm --interactive stedolan/jq ".assets[] | select(.name==\"${assetName}\") | .id")
 
-curl -L \
-  -H "Accept: application/octet-stream" \
-  --output $assetName \
-  https://api.github.com/repos/hmcts/${repoName}/releases/assets/${latestAssetId} \
+  curl -L \
+    -H "Accept: application/octet-stream" \
+    --output $assetName \
+    https://api.github.com/repos/hmcts/${repoName}/releases/assets/${latestAssetId}
+
+  retries=$((retries+1))
+  echo "Try ${retries}"
+
+  if [ "$retries" -eq 5 ]
+  then
+      echo "Unable to get latest release from GitHub API"
+      exit 1
+  fi
+done
 
 unzip $assetName
 rm $assetName

--- a/bin/pull-latest-release-asset.sh
+++ b/bin/pull-latest-release-asset.sh
@@ -6,8 +6,10 @@ assetName=$2
 for retries in {1..5}
 do
   echo "Try ${retries}"
+  latestAsset=$(curl https://api.github.com/repos/hmcts/${repoName}/releases/latest)
+  echo $latestAsset
 
-  latestAssetId=$(curl https://api.github.com/repos/hmcts/${repoName}/releases/latest \
+  latestAssetId=$(echo $latestAsset \
    | docker run --rm --interactive stedolan/jq ".assets[] | select(.name==\"${assetName}\") | .id")
 
   curl -L \

--- a/bin/pull-latest-release-asset.sh
+++ b/bin/pull-latest-release-asset.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-getToken() {
-  az keyvault secret show --vault-name infra-vault-nonprod --name hmcts-github-apikey --query value -o tsv
-}
-
 repoName=$1
 assetName=$2
-token=$(getToken)
+
+az login --identity
+token=$(az keyvault secret show --vault-name infra-vault-nonprod --name hmcts-github-apikey \
+ --query value -o tsv)
 
 latestAssetId=$(curl -H "Authorization: token ${token}" \
   https://api.github.com/repos/hmcts/${repoName}/releases/latest \

--- a/bin/pull-latest-release-asset.sh
+++ b/bin/pull-latest-release-asset.sh
@@ -1,31 +1,22 @@
 #!/usr/bin/env bash
 
+getToken() {
+  az keyvault secret show --vault-name infra-vault-nonprod --name hmcts-github-apikey --query value -o tsv
+}
+
 repoName=$1
 assetName=$2
+token=$(getToken)
 
-for retries in {1..5}
-do
-  echo "Try ${retries}"
-  latestAsset=$(curl https://api.github.com/repos/hmcts/${repoName}/releases/latest)
-  echo $latestAsset
+latestAssetId=$(curl -H "Authorization: token ${token}" \
+  https://api.github.com/repos/hmcts/${repoName}/releases/latest \
+  | docker run --rm --interactive stedolan/jq ".assets[] | select(.name==\"${assetName}\") | .id")
 
-  latestAssetId=$(echo $latestAsset \
-   | docker run --rm --interactive stedolan/jq ".assets[] | select(.name==\"${assetName}\") | .id")
+curl -L \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: token ${token}" \
+  --output $assetName \
+  https://api.github.com/repos/hmcts/${repoName}/releases/assets/${latestAssetId} \
 
-  curl -L \
-    -H "Accept: application/octet-stream" \
-    --output $assetName \
-    https://api.github.com/repos/hmcts/${repoName}/releases/assets/${latestAssetId}
-
-  unzip -o $assetName
-  unzipExitStatus=$?
-  rm $assetName
-
-  if [ "$unzipExitStatus" -eq 0 ]
-  then
-    exit 0
-  fi
-done
-
-echo "Unable to get latest release from GitHub API"
-exit 1
+unzip $assetName
+rm $assetName


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1688

### Change description ###

The fix for this was changed when it was found that the reason the script fails was because the GitHub API calls were being rate limited

`{"message":"API rate limit exceeded for 20.50.109.148. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}`

Adding an authentication token to the API call increases the rate limit

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
