### PR TITLE
fix: wait for promise to resolve on runAccessibility method

### DIFF
--- a/e2e/helpers/browser_helper.js
+++ b/e2e/helpers/browser_helper.js
@@ -57,6 +57,6 @@ module.exports = class BrowserHelpers extends Helper {
     const url = await this.getHelper().grabCurrentUrl();
     const {page} = await this.getHelper();
 
-    runAccessibility(url, page);
+    await runAccessibility(url, page);
   }
 };


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

add await to runAccessibility method.

Should solve following error:

```
[2021-06-29T15:15:24.485Z] (node:26047) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'addScriptTag' of undefined

[2021-06-29T15:15:24.485Z]     at runAccessibility (/opt/jenkins/workspace/ghtly_Civil_civil-service_master/e2e/helpers/accessibility/runner.js:19:14)

[2021-06-29T15:15:24.485Z]     at BrowserHelpers.runAccessibilityTest (/opt/jenkins/workspace/ghtly_Civil_civil-service_master/e2e/helpers/browser_helper.js:60:5)

[2021-06-29T15:15:24.485Z]     at processTicksAndRejections (internal/process/task_queues.js:97:5)

[2021-06-29T15:15:24.485Z]     at async Object.enterLitigantFriendWithDifferentAddressToApplicant (/opt/jenkins/workspace/ghtly_Civil_civil-service_master/e2e/pages/createClaim/claimantLitigationDetails.page.js:18:5)
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
