### PR TITLE
Revert "fix: wait for promise to resolve on runAccessibility method"

### DIFF
--- a/e2e/helpers/browser_helper.js
+++ b/e2e/helpers/browser_helper.js
@@ -57,6 +57,6 @@ module.exports = class BrowserHelpers extends Helper {
     const url = await this.getHelper().grabCurrentUrl();
     const {page} = await this.getHelper();
 
-    await runAccessibility(url, page);
+    runAccessibility(url, page);
   }
 };


### PR DESCRIPTION
Reverts hmcts/civil-ccd-definition#143

All crossbrowser tests now failing due to 


```
06:46:23    1) End-to-end journey @cross-browser-tests
06:46:23         Full end-to-end journey:
06:46:23       Cannot read property 'addScriptTag' of undefined
```