### PR TITLE
fix: E2E failures screenshotted (CMC-1700)

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -18,9 +18,6 @@ exports.config = {
     GenerateReportHelper: {
       require: './e2e/helpers/generate_report_helper.js'
     },
-    SauceLabsReportingHelper: {
-      require: './e2e/helpers/sauce_labs_reporting_helper.js',
-    },
   },
   include: {
     I: './e2e/steps_file.js',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1700

### Change description ###

`sauce_labs_reporting_helper.js` was causing an error when running the e2e tests since it doesn't account for using Puppeteer instead of WebDriver. This stopped screenshots from being taken on test failures. 

Sauce Labs is only used in nightly crossbrowser tests which uses a different config `saucelabs.conf.js` so can be safely removed from the default config.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
