### PR TITLE
feat: Staff can add notes to pending claims (CMC-1762)

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents.json
+++ b/ccd-definition/CaseEvent/User/UserEvents.json
@@ -258,7 +258,7 @@
     "Name": "Add a case note",
     "Description": "Add a case note",
     "DisplayOrder": 16,
-    "PreConditionState(s)": "CASE_ISSUED;AWAITING_CASE_DETAILS_NOTIFICATION;AWAITING_RESPONDENT_ACKNOWLEDGEMENT;AWAITING_APPLICANT_INTENTION;CASE_DISMISSED",
+    "PreConditionState(s)": "PENDING_CASE_ISSUED;CASE_ISSUED;AWAITING_CASE_DETAILS_NOTIFICATION;AWAITING_RESPONDENT_ACKNOWLEDGEMENT;AWAITING_APPLICANT_INTENTION;CASE_DISMISSED",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
     "ShowSummary": "Y",


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CMC-1762


### Change description ###
- Member of staff can now trigger `Add a case note` when case state is `CLAIM ISSUE PENDING`.

**Note:**
Civil services needed no additional changes as `Add a case note` is already allowed as a transition by the state flow engine. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
