### PR TITLE
feat/CMC-1845: Show Respondent 2 Org on Claim Details Tab

### DIFF
--- a/ccd-definition/CaseField/CaseField.json
+++ b/ccd-definition/CaseField/CaseField.json
@@ -906,7 +906,7 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "respondent2OrganisationPolicy",
-    "Label": "Respondent 2 organisation policy",
+    "Label": "Defendant 2's legal representative",
     "FieldType": "OrganisationPolicy",
     "SecurityClassification": "Public"
   },

--- a/ccd-definition/CaseTypeTab/ClaimDetails.json
+++ b/ccd-definition/CaseTypeTab/ClaimDetails.json
@@ -110,5 +110,13 @@
     "TabDisplayOrder": 2,
     "CaseFieldID": "respondent1OrganisationPolicy",
     "TabFieldDisplayOrder": 14
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "TabID": "ClaimDetails",
+    "TabLabel": "Claim Details",
+    "TabDisplayOrder": 2,
+    "CaseFieldID": "respondent2OrganisationPolicy",
+    "TabFieldDisplayOrder": 15
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1845

### Change description ###
- Adding the `respondent2OrganisationPolicy` Field on the ClaimDetails page
- Updating label for this field to be consistent with `respondent1OrganisationPolicy`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
