### PR TITLE
feat/CIV-816 fixed: witnesses field admits only numbers

### DIFF
--- a/ccd-definition/CaseField/CaseFieldLRspec.json
+++ b/ccd-definition/CaseField/CaseFieldLRspec.json
@@ -661,6 +661,7 @@
     "ID": "responseClaimWitnesses",
     "Label": "How many witnesses, including the defendant, will give evidence at the hearing?",
     "FieldType": "Text",
+    "RegularExpression": "\\d+",
     "SecurityClassification": "Public"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-816


### Change description ###
The field has been updated with a regex allowing only numbers. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
