### PR TITLE
CIV-861: Add email notify sdo event

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
@@ -1,0 +1,42 @@
+[
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-systemupdate"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "[APPLICANTSOLICITORONE]",
+          "[RESPONDENTSOLICITORONE]",
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR1_SDO_TRIGGERED",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-systemupdate"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "[APPLICANTSOLICITORONE]",
+          "[RESPONDENTSOLICITORONE]",
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  }
+]

--- a/ccd-definition/CaseEvent/Camunda/NotificationEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/Camunda/NotificationEvents-SDO-nonprod.json
@@ -1,0 +1,28 @@
+[
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED",
+    "Name": "Email: Notify SDO Triggered",
+    "Description": "Notify applicant solictor one that a sdo has been triggered",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "RetriesTimeoutURLAboutToSubmitEvent": 0
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "NOTIFY_RESPONDENT_SOLICITOR1_SDO_TRIGGERED",
+    "Name": "Email: Notify SDO Triggered",
+    "Description": "Notify respondent solicitor one that a sdo has been triggered",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "RetriesTimeoutURLAboutToSubmitEvent": 0
+  }
+]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-861


### Change description ###
This PR creates a new ccd event (`NOTIFY_PARTIES_SDO_TRIGGERED`) representing the event to notify relevant parties that an SDO has been triggered on a case. It has a callback that will be handled by a handler in a future PR.

There will be two event authorizations for now as the file that the event was created in has been created in a [previous PR](https://github.com/hmcts/civil-ccd-definition/pull/334/files) that is not merged in yet due to pipeline issues, once that has been merged in the changes compared to Master should be just the new event authorization entry.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
