### PR TITLE
CMC-1520: Remove-V_1_about-to-start-acknowledge-claim

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents.json
+++ b/ccd-definition/CaseEvent/User/UserEvents.json
@@ -63,7 +63,7 @@
     "PreConditionState(s)": "AWAITING_RESPONDENT_ACKNOWLEDGEMENT",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
-    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/version/V_1/about-to-start",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-start",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/version/V_1/about-to-submit",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "Y",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1520


### Change description ###
Change from v1 callback for about-to-submit, acknowledge claim to just about-to-submit (no version)
Linked to -> https://github.com/hmcts/civil-service/pull/572  (Freeing up the V1 callback)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
