### PR TITLE
fix: Alter DefendantResponse.json fields show conditions

### DIFF
--- a/ccd-definition/CaseEventToFields/DefendantResponse.json
+++ b/ccd-definition/CaseEventToFields/DefendantResponse.json
@@ -614,7 +614,7 @@
     "DisplayContext": "COMPLEX",
     "PageID": "Experts",
     "CaseEventFieldLabel": "Experts",
-    "PageShowCondition": "multiPartyResponseTypeFlags=\"FULL_DEFENCE\"",
+    "PageShowCondition": "multiPartyResponseTypeFlags=\"FULL_DEFENCE\" AND respondent2SameLegalRepresentative=\"YES\"",
     "FieldShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" OR respondent1ClaimResponseTypeToApplicant2=\"FULL_DEFENCE\"",
     "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/experts",
     "RetriesTimeoutURLMidEvent": 0,
@@ -948,7 +948,6 @@
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "COMPLEX",
     "PageID": "Upload",
-    "FieldShowCondition": "respondent2ClaimResponseType=\"FULL_DEFENCE\"",
     "ShowSummaryChangeOption": "Y"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A - 


### Change description ###
Changing field show conditions in defendant response journey for respondent 2

1v2 - 2 Legal Rep Issues, defendant 2 submitting a response
- Currently respondent 2 upload of documents are not showing 
(Current logic suggests this should only be visible when full defence - which is not correct)
- When Defendant 2 continues through the journey having said Full Admit / Part Admit / Counter Claim, they should not see DQ pages (Witnesses, Experts Etc) Currently the page is showing because the condition is met, but the respondent 2 does not have access to view respondent 1s field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
