### PR TITLE
resolving role assignment error on pipeline

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
@@ -38,11 +38,6 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
     }
 
     @Override
-    protected boolean shouldTolerateDataSetupFailure() {
-        return true;
-    }
-
-    @Override
     public void addCcdRoles() {
         for (CcdRoleConfig roleConfig : CCD_ROLES_NEEDED_FOR_NFD) {
             try {

--- a/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.befta.dse.ccd.CcdEnvironment;
 import uk.gov.hmcts.befta.dse.ccd.CcdRoleConfig;
 import uk.gov.hmcts.befta.dse.ccd.DataLoaderToDefinitionStore;
+import uk.gov.hmcts.befta.util.BeftaUtils;
 
 import java.util.List;
 import java.util.Locale;
@@ -61,5 +62,11 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
     protected List<String> getAllDefinitionFilesToLoadAt(String definitionsPath) {
         String environmentName = environment.name().toLowerCase(Locale.UK);
         return List.of(String.format("build/ccd-release-config/civil-ccd-%s.xlsx", environmentName));
+    }
+
+    @Override
+    public void createRoleAssignments() {
+        // Do not create role assignments.
+        BeftaUtils.defaultLog("Will NOT create role assignments!");
     }
 }


### PR DESCRIPTION
### Change description ###
To resolve our pipeline issues as recommended under https://tools.hmcts.net/jira/browse/CFTS-2045 making following changes:

1. Removing the override of shouldTolerateDataSetupFailure method to true so that if high level data setup fails we don't see a green but a red.
2. Overriding createRoleAssignments to do nothing to remove the red herring:
"Caused by: java.lang.NullPointerException: Environment variable `ROLE_ASSIGNMENT_USER_PASSWORD` is required"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
