### PR TITLE
Feat/cmc 1939 time extension defendant response

### DIFF
--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -41,7 +41,7 @@ const data = {
 };
 
 const eventData = {
-  acknowledgeClaim: {
+  acknowledgeClaims: {
     ONE_V_ONE: data.ACKNOWLEDGE_CLAIM,
     ONE_V_TWO_ONE_LEGAL_REP: data.ACKNOWLEDGE_CLAIM_SAME_SOLICITOR,
     ONE_V_TWO_TWO_LEGAL_REP: {
@@ -50,7 +50,7 @@ const eventData = {
     },
     TWO_V_ONE: data.ACKNOWLEDGE_CLAIM
   },
-  informAgreedExtensionDate: {
+  informAgreedExtensionDates: {
     ONE_V_ONE: data.INFORM_AGREED_EXTENSION_DATE,
     ONE_V_TWO_ONE_LEGAL_REP: data.INFORM_AGREED_EXTENSION_DATE,
     ONE_V_TWO_TWO_LEGAL_REP: {
@@ -59,7 +59,7 @@ const eventData = {
     },
     TWO_V_ONE: data.INFORM_AGREED_EXTENSION_DATE
   },
-  defendantResponse:{
+  defendantResponses:{
     ONE_V_ONE: data.DEFENDANT_RESPONSE,
     ONE_V_TWO_ONE_LEGAL_REP: data.DEFENDANT_RESPONSE_SAME_SOLICITOR,
     ONE_V_TWO_TWO_LEGAL_REP: {
@@ -329,9 +329,9 @@ module.exports = {
     }
 
     if(mpScenario !== 'ONE_V_TWO_TWO_LEGAL_REP') {
-      await validateEventPages(eventData['acknowledgeClaim'][mpScenario]);
+      await validateEventPages(eventData['acknowledgeClaims'][mpScenario]);
     } else {
-      await validateEventPages(eventData['acknowledgeClaim'][mpScenario][solicitor]);
+      await validateEventPages(eventData['acknowledgeClaims'][mpScenario][solicitor]);
     }
 
     await assertError('ConfirmNameAddress', data[eventName].invalid.ConfirmDetails.futureDateOfBirth,
@@ -367,9 +367,9 @@ module.exports = {
 
     let informAgreedExtensionData;
     if(mpScenario !== 'ONE_V_TWO_TWO_LEGAL_REP') {
-      informAgreedExtensionData = eventData['informAgreedExtensionDate'][mpScenario];
+      informAgreedExtensionData = eventData['informAgreedExtensionDates'][mpScenario];
     } else {
-      informAgreedExtensionData = eventData['informAgreedExtensionDate'][mpScenario][solicitor];
+      informAgreedExtensionData = eventData['informAgreedExtensionDates'][mpScenario][solicitor];
     }
 
     await validateEventPages(informAgreedExtensionData, solicitor);
@@ -409,9 +409,9 @@ module.exports = {
 
     let defendantResponseData;
     if(mpScenario !== 'ONE_V_TWO_TWO_LEGAL_REP') {
-      defendantResponseData = eventData['defendantResponse'][mpScenario];
+      defendantResponseData = eventData['defendantResponses'][mpScenario];
     } else {
-      defendantResponseData = eventData['defendantResponse'][mpScenario][solicitor];
+      defendantResponseData = eventData['defendantResponses'][mpScenario][solicitor];
     }
 
     assertContainsPopulatedFields(returnedCaseData);

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -50,6 +50,15 @@ const eventData = {
     },
     TWO_V_ONE: data.ACKNOWLEDGE_CLAIM
   },
+  informAgreedExtensionDate: {
+    ONE_V_ONE: data.INFORM_AGREED_EXTENSION_DATE,
+    ONE_V_TWO_ONE_LEGAL_REP: data.INFORM_AGREED_EXTENSION_DATE,
+    ONE_V_TWO_TWO_LEGAL_REP: {
+      solicitorOne: data.INFORM_AGREED_EXTENSION_DATE,
+      solicitorTwo: data.INFORM_AGREED_EXTENSION_DATE_SOLICITOR_TWO
+    },
+    TWO_V_ONE: data.INFORM_AGREED_EXTENSION_DATE
+  },
   defendantResponse:{
     ONE_V_ONE: data.DEFENDANT_RESPONSE,
     ONE_V_TWO_ONE_LEGAL_REP: data.DEFENDANT_RESPONSE_SAME_SOLICITOR,
@@ -356,11 +365,18 @@ module.exports = {
     caseData = returnedCaseData;
     deleteCaseFields('systemGeneratedCaseDocuments');
 
-    await validateEventPages(data[eventName], solicitor);
+    let informAgreedExtensionData;
+    if(mpScenario !== 'ONE_V_TWO_TWO_LEGAL_REP') {
+      informAgreedExtensionData = eventData['informAgreedExtensionDate'][mpScenario];
+    } else {
+      informAgreedExtensionData = eventData['informAgreedExtensionDate'][mpScenario][solicitor];
+    }
 
-    await assertError('ExtensionDate', data[eventName].invalid.ExtensionDate.past,
+    await validateEventPages(informAgreedExtensionData, solicitor);
+
+    await assertError('ExtensionDate', informAgreedExtensionData.invalid.ExtensionDate.past,
       'The agreed extension date must be a date in the future');
-    await assertError('ExtensionDate', data[eventName].invalid.ExtensionDate.beforeCurrentDeadline,
+    await assertError('ExtensionDate', informAgreedExtensionData.invalid.ExtensionDate.beforeCurrentDeadline,
       'The agreed extension date must be after the current deadline');
 
     await assertSubmittedEvent('AWAITING_RESPONDENT_ACKNOWLEDGEMENT', {

--- a/e2e/fixtures/events/1v2DifferentSolicitorEvents/informAgreeExtensionDate_Solicitor2.js
+++ b/e2e/fixtures/events/1v2DifferentSolicitorEvents/informAgreeExtensionDate_Solicitor2.js
@@ -3,7 +3,7 @@ const {date} = require('../../../api/dataHelper');
 module.exports = {
   valid: {
     ExtensionDate: {
-      respondentSolicitor2AgreedDeadlineExtension: date(30)
+      respondentSolicitor2AgreedDeadlineExtension: date(40)
     }
   },
   invalid: {

--- a/e2e/tests/api_multiparty/api_1v2_different_solicitor_test.js
+++ b/e2e/tests/api_multiparty/api_1v2_different_solicitor_test.js
@@ -42,9 +42,8 @@ Scenario('Inform agreed extension date Solicitor 1', async ({I, api}) => {
   await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario, 'solicitorOne');
 });
 
-// TODO: Skipping this until CMC-1939 is fixed
-Scenario.skip('Inform agreed extension date Solicitor 2', async ({I, api}) => {
-  await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario, 'solicitorTwo');
+Scenario('Inform agreed extension date Solicitor 2', async ({I, api}) => {
+  await api.informAgreedExtension(config.secondDefendantSolicitorUser, mpScenario, 'solicitorTwo');
 });
 
 Scenario('Defendant response Solicitor 1', async ({I, api}) => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1939

Civil service repo:
https://github.com/hmcts/civil-service/pull/656

### Change description ###
- unskip inform agreed extension date for solictor 2 in api test after fixing code in civil service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
