### PR TITLE
feat: restrict defendant 2 reference field length

### DIFF
--- a/ccd-definition/CaseField/CaseField.json
+++ b/ccd-definition/CaseField/CaseField.json
@@ -1313,7 +1313,8 @@
     "ID": "respondentSolicitor2Reference",
     "Label": "Defendant's legal representative's reference",
     "FieldType": "Text",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": "24"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1950


### Change description ###
Constrain the Defendant 2 reference field length to same as defendant 1 and claimant reference


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
