### PR TITLE
Removed cve redundant suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,63 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2030-01-01">
-    <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-    <gav regex="true">.*</gav>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
-  <suppress until="2030-01-01">
-    <notes><![CDATA[Awaiting version bump from jackson-module-kotlin to take 1.3.7 -> 1.4]]></notes>
-    <cve>CVE-2020-15824</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
-  ]]></notes>
-    <cve>CVE-2020-10663</cve>
-    <cve>CVE-2020-7712</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[Awaiting openid dependencies version bump in nimbus-jose-jwt]]></notes>
-    <cve>CVE-2007-1651</cve>
-    <cve>CVE-2007-1652</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[Awaiting version bump for apache tomcat dependencies]]></notes>
-    <cve>CVE-2020-13943</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[This vulnerability can only be exploited from the local network.]]></notes>
-    <gav regex="true">^org\.owasp\.encoder:encoder-jsp:.*$</gav>
-    <cve>CVE-2020-29242</cve>
-    <cve>CVE-2020-29243</cve>
-    <cve>CVE-2020-29244</cve>
-    <cve>CVE-2020-29245</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[This vulnerability can only be exploited from the local network.]]></notes>
-    <gav regex="true">^com\.nimbusds:lang-tag:.*$</gav>
-    <cve>CVE-2020-29242</cve>
-    <cve>CVE-2020-29243</cve>
-    <cve>CVE-2020-29244</cve>
-    <cve>CVE-2020-29245</cve>
-  </suppress>
   <suppress>
     <notes><![CDATA[file name: guava-28.2-jre.jar]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
     <cve>CVE-2020-8908</cve>
   </suppress>
   <suppress>
-    <notes><![CDATA[suppresses false positive see (https://github.com/jeremylong/DependencyCheck/issues/2785)]]></notes>
-    <cve>CVE-2020-29582</cve>
-    <cpe>cpe:/2.3:a:jetbrains:kotlin:1.4.0:milestone1:*:*:*:*:*:*</cpe>
-  </suppress>
-  <suppress>
-    <cve>CVE-2019-12402</cve>
-    <cve>CVE-2016-5394</cve>
-    <cve>CVE-2016-6798</cve>
     <cve>CVE-2019-12415</cve>
   </suppress>
   <suppress>
@@ -65,8 +13,6 @@
     <cve>CVE-2020-26939</cve>
     <cve>CVE-2017-13098</cve>
     <cve>CVE-2018-1000180</cve>
-    <cve>CVE-2020-17521</cve>
-    <cve>CVE-2020-13956</cve>
     <cve>CVE-2020-25649</cve>
     <cve>CVE-2018-1000873</cve>
     <cve>CVE-2020-15250</cve>
@@ -75,8 +21,6 @@
     <cve>CVE-2020-5398</cve>
     <cve>CVE-2020-5421</cve>
     <cve>CVE-2018-15756</cve>
-    <cve>CVE-2022-23181</cve>
-    <cve>CVE-2021-22060</cve>
     <cve>CVE-2021-42550</cve>
     <cve>CVE-2021-44228</cve>
     <cve>CVE-2021-44832</cve>
@@ -86,5 +30,14 @@
     <cve>CVE-2021-44832</cve>
     <cve>CVE-2021-45046</cve>
     <cve>CVE-2021-45105</cve>
+  </suppress>
+  <suppress>
+    <notes>MEDIUM-jquery-suppressed at 21-02-2022</notes>
+    <cve>CVE-2020-11022</cve>
+    <cve>CVE-2020-11023</cve>
+  </suppress>
+  <suppress>
+    <notes>HIGH-Spring security-suppressed at 21-02-2022</notes>
+    <cve>CVE-2021-22112</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-1957

- Removed redundant cve suppressions
- Temporarily suppressed three new dependency issues:
- Spring security - CVE-2021-22112 - HIGH
- jquery- CVE-2020-11022, CVE-2020-11023 - MEDIUM
 