### PR TITLE
CIV-866 adds callback for CREATE_SDO event

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
@@ -8,6 +8,8 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/version/V_1/about-to-submit",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "Y",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Submit",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-869


### Change description ###
For the AC's to be met within the above ticket, these callbacks need to be added to the ccd event. This should've been done in a [previous PR](https://github.com/hmcts/civil-ccd-definition/pull/540) which contained the changes for [this ticket](https://tools.hmcts.net/jira/browse/CIV-861) which is where the changes in this PR should have realistically been.

This is a straightforward PR and none of the previous changes without the changes in this PR have cause any issues or introduce any broken code. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
