### PR TITLE
build/bump-charts: Update java charts to v3.7.2

### DIFF
--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -28,6 +28,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: camunda-bpm
-    version: 0.0.18
+    version: 0.0.23
     repository: '@hmctspublic'
     condition: camunda-bpm.enabled

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -8,10 +8,10 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.3
+    version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
-    version: 6.0.0
+    version: 7.0.0
     repository: '@hmctspublic'
     tags:
       - civil-ccd-stack

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
-    version: 7.0.0
+    version: 6.0.0
     repository: '@hmctspublic'
     tags:
       - civil-ccd-stack

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 description: A Helm chart for civil-ccd App
 name: civil-ccd
 home: https://github.com/hmcts/civil-ccd-definition
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: HMCTS Civil team
 
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.3
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0


### PR DESCRIPTION
### JIRA link (if applicable) ###
- Bump java charts to v3.7.2
- Bump camunda-bpm to 0.0.23


### Change description ###
N/A


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
