### PR TITLE
[Improvements] - Only when enableHelm label added then Helm Release will be retained 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -2,6 +2,7 @@
 
 @Library("Infrastructure")
 import uk.gov.hmcts.contino.AppPipelineConfig
+import uk.gov.hmcts.contino.GithubAPI
 
 def type = "java"
 def product = "civil"
@@ -103,6 +104,10 @@ def uploadCoreCaseDataDefinitions(env) {
   }
 }
 
+def checkForEnableHelmLabel(branch_name) {
+    return new GithubAPI(this).getLabelsbyPattern(branch_name, "enableHelm").contains("enableHelm")
+}
+
 withPipeline(type, product, component) {
   pipelineConf = config
   disableLegacyDeployment()
@@ -115,6 +120,9 @@ withPipeline(type, product, component) {
   onPR {
     env.ENVIRONMENT = "preview"
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-civil-ccd-pr-${CHANGE_ID}.service.core-compute-preview.internal"
+    if (!checkForEnableHelmLabel(env.BRANCH_NAME)) {
+      enableCleanupOfHelmReleaseOnSuccess();
+    }
   }
   onMaster {
     env.ENVIRONMENT="aat"

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
 }
 
 task runFunctionalTests(type: Exec, description: 'Runs functional tests.') {
-  commandLine '/usr/bin/yarn', '--silent', 'test:smoke'
+  commandLine '/usr/bin/yarn', '--silent', 'test:functional'
 }
 
 task runRpaHandOffTests(type: Exec, description: 'Runs functional tests.') {

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
 }
 
 task runFunctionalTests(type: Exec, description: 'Runs functional tests.') {
-  commandLine '/usr/bin/yarn', '--silent', 'test:functional'
+  commandLine '/usr/bin/yarn', '--silent', 'test:smoke'
 }
 
 task runRpaHandOffTests(type: Exec, description: 'Runs functional tests.') {

--- a/e2e/steps_file.js
+++ b/e2e/steps_file.js
@@ -201,7 +201,7 @@ module.exports = function () {
       }
 
       await this.retryUntilExists(async () => {
-        this.amOnPage(config.url.manageCase, 60);
+        this.amOnPage(config.url.manageCase, 90);
 
         if (!config.idamStub.enabled || config.idamStub.enabled === 'false') {
           output.log(`Signing in user: ${user.type}`);

--- a/e2e/tests/1v1Journey_test.js
+++ b/e2e/tests/1v1Journey_test.js
@@ -16,7 +16,7 @@ const respondent1 = {
 
 let caseNumber;
 
-Feature('1v1 - Claim Journey @e2e-multiparty');
+Feature('1v1 - Claim Journey @e2e-unspec @e2e-multiparty');
 
 Scenario('Applicant solicitor creates claim @create-claim', async ({I}) => {
   await I.login(config.applicantSolicitorUser);

--- a/e2e/tests/api_1v1_test.js
+++ b/e2e/tests/api_1v1_test.js
@@ -3,7 +3,7 @@
 const config = require('../config.js');
 const mpScenario = 'ONE_V_ONE';
 
-Feature('CCD 1v1 API test @api-multiparty @api-tests-1v1');
+Feature('CCD 1v1 API test @api-unspec @api-multiparty @api-tests-1v1');
 
 Scenario('Create claim', async ({I, api}) => {
   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);

--- a/e2e/tests/api_multiparty/api_1v2_different_solicitor_test.js
+++ b/e2e/tests/api_multiparty/api_1v2_different_solicitor_test.js
@@ -4,7 +4,7 @@ const config = require('../../config.js');
 const mpScenario = 'ONE_V_TWO_TWO_LEGAL_REP';
 
 // add @api-tests to run
-Feature('CCD 1v2 Different Solicitor API test @api-multiparty @api-tests-1v2DS');
+Feature('CCD 1v2 Different Solicitor API test @api-unspec @api-multiparty @api-tests-1v2DS');
 
 Scenario('Create claim', async ({I, api}) => {
   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);

--- a/e2e/tests/api_multiparty/api_1v2_same_solicitor_test.js
+++ b/e2e/tests/api_multiparty/api_1v2_same_solicitor_test.js
@@ -4,7 +4,7 @@ const config = require('../../config.js');
 const mpScenario = 'ONE_V_TWO_ONE_LEGAL_REP';
 
 
-Feature('CCD 1v2 Same Solicitor API test @api-multiparty @api-tests-1v2SS');
+Feature('CCD 1v2 Same Solicitor API test @api-unspec @api-tests-1v2SS');
 
 Scenario('Create claim', async ({I, api}) => {
   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);

--- a/e2e/tests/api_multiparty/api_2v1_test.js
+++ b/e2e/tests/api_multiparty/api_2v1_test.js
@@ -3,7 +3,7 @@
 const config = require('../../config.js');
 const mpScenario = 'TWO_V_ONE';
 
-Feature('CCD 1v2 Same Solicitor API test @api-multiparty @api-tests-2v1');
+Feature('CCD 1v2 Same Solicitor API test @api-unspec @api-multiparty @api-tests-2v1');
 
 Scenario('Create claim', async ({I, api}) => {
   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);

--- a/e2e/tests/multiparty/1v2CreateClaim_test.js
+++ b/e2e/tests/multiparty/1v2CreateClaim_test.js
@@ -16,7 +16,7 @@ const respondent2 = {
 let caseNumber;
 
 
-Feature('1v2 Create claim @e2e-multiparty');
+Feature('1v2 Create claim @e2e-unspec @e2e-multiparty');
 
 Scenario('Claimant solicitor raise a claim against 2 defendants, one of who is without a solicitor (LiP) should progress case offline', async ({I}) => {
   await I.login(config.applicantSolicitorUser);

--- a/e2e/tests/multiparty/1v2DiffSolJourney_test.js
+++ b/e2e/tests/multiparty/1v2DiffSolJourney_test.js
@@ -21,7 +21,7 @@ const respondent2 = {
 
 let caseNumber;
 
-Feature('1v2 Different Solicitors Claim Journey @e2e-nightly');
+Feature('1v2 Different Solicitors Claim Journey @e2e-unspec @e2e-nightly');
 
 Scenario('Claimant solicitor raises a claim against 2 defendants who have different solicitors', async ({I}) => {
   await I.login(config.applicantSolicitorUser);

--- a/e2e/tests/multiparty/1v2SameSolJourney_test.js
+++ b/e2e/tests/multiparty/1v2SameSolJourney_test.js
@@ -21,7 +21,7 @@ const respondent2 = {
 
 let caseNumber;
 
-Feature('1v2 Same Solicitor Claim Journey @e2e-multiparty');
+Feature('1v2 Same Solicitor Claim Journey @e2e-unspec @e2e-multiparty');
 
 Scenario('Claimant solicitor raises a claim against 2 defendants who have the same solicitor', async ({I}) => {
   await I.login(config.applicantSolicitorUser);

--- a/e2e/tests/multiparty/2v1Journey_test.js
+++ b/e2e/tests/multiparty/2v1Journey_test.js
@@ -18,7 +18,7 @@ const respondent1 = {
 
 let caseNumber;
 
-Feature('2v1 Claim Journey @e2e-nightly');
+Feature('2v1 Claim Journey @e2e-unspec @e2e-nightly');
 
 
 Scenario('Claimant solicitor raises a claim for 2 claimants against 1 defendant', async ({I}) => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "test": "npx codeceptjs run --steps",
     "test:smoke": "MOCHAWESOME_REPORTFILENAME=smoke npx codeceptjs run --grep @smoke-tests --reporter mocha-multi --verbose",
     "test:smoke-spec": "MOCHAWESOME_REPORTFILENAME=smoke npx codeceptjs run --grep @smoke-tests-spec --reporter mocha-multi --verbose",
+    "test:api-unspec": "MOCHAWESOME_REPORTFILENAME=api npx codeceptjs run --grep @api-unspec --reporter mocha-multi --verbose",
+    "test:e2e-unspec": "MOCHAWESOME_REPORTFILENAME=api npx codeceptjs run --grep @e2e-unspec --reporter mocha-multi --verbose",
     "test:api": "MOCHAWESOME_REPORTFILENAME=api npx codeceptjs run --grep @api-multiparty --reporter mocha-multi --verbose",
     "test:api-1v1": "MOCHAWESOME_REPORTFILENAME=api npx codeceptjs run --grep @api-tests-1v1 --reporter mocha-multi --verbose",
     "test:api-1v2SS": "MOCHAWESOME_REPORTFILENAME=api npx codeceptjs run --grep @api-tests-1v2SS --reporter mocha-multi --verbose",


### PR DESCRIPTION
With this Pr change -->C ivil ccd defintion deployed helm resources will be deleted by default on successful PR.
If anyone wants to retain helm release for testing they have to add a label "enableHelm" It is already added to labels list.

See below screenshot for reference

<img width="677" alt="Screenshot 2022-02-24 at 12 56 59" src="https://user-images.githubusercontent.com/43175082/155528286-40bb4104-b8da-4fb6-9d77-ab8300ff6b9c.png">
