### PR TITLE
update sdo notification events for multiparty

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
@@ -14,7 +14,7 @@
   },
   {
     "CaseTypeID": "CIVIL",
-    "CaseEventID": "NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED",
+    "CaseEventID": "NOTIFY_APPLICANTS_SOLICITOR_SDO_TRIGGERED",
     "AccessControl": [
       {
         "UserRoles": [
@@ -25,7 +25,9 @@
       {
         "UserRoles": [
           "[APPLICANTSOLICITORONE]",
+          "[APPLICANTSOLICITORTWO]",
           "[RESPONDENTSOLICITORONE]",
+          "[RESPONDENTSOLICITORTWO]",
           "caseworker-civil-admin"
         ],
         "CRUD": "R"
@@ -45,7 +47,31 @@
       {
         "UserRoles": [
           "[APPLICANTSOLICITORONE]",
+          "[APPLICANTSOLICITORTWO]",
           "[RESPONDENTSOLICITORONE]",
+          "[RESPONDENTSOLICITORTWO]",
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR2_SDO_TRIGGERED",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-systemupdate"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "[APPLICANTSOLICITORONE]",
+          "[APPLICANTSOLICITORTWO]",
+          "[RESPONDENTSOLICITORONE]",
+          "[RESPONDENTSOLICITORTWO]",
           "caseworker-civil-admin"
         ],
         "CRUD": "R"

--- a/ccd-definition/CaseEvent/Camunda/NotificationEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/Camunda/NotificationEvents-SDO-nonprod.json
@@ -1,9 +1,9 @@
 [
   {
     "CaseTypeID": "CIVIL",
-    "ID": "NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED",
+    "ID": "NOTIFY_APPLICANTS_SOLICITOR_SDO_TRIGGERED",
     "Name": "Email: Notify SDO Triggered",
-    "Description": "Notify applicant solictor one that a sdo has been triggered",
+    "Description": "Notify applicant(s) solictor that a sdo has been triggered",
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
@@ -16,7 +16,20 @@
     "CaseTypeID": "CIVIL",
     "ID": "NOTIFY_RESPONDENT_SOLICITOR1_SDO_TRIGGERED",
     "Name": "Email: Notify SDO Triggered",
-    "Description": "Notify respondent solicitor one that a sdo has been triggered",
+    "Description": "Notify respondent solicitor 1 that a sdo has been triggered",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "RetriesTimeoutURLAboutToSubmitEvent": 0
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "NOTIFY_RESPONDENT_SOLICITOR2_SDO_TRIGGERED",
+    "Name": "Email: Notify SDO Triggered",
+    "Description": "Notify respondent solicitor 2 that a sdo has been triggered",
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1376


### Change description ###
This PR adds new notification events within CCD to be used by Camunda in the `CREATE_SDO` journey.

The reason a second event isn't needed for the applicant solicitor is because the applicants within this journey will always have the same legal rep and therefore the same solicitor.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
