### PR TITLE
add additional directions options

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
@@ -79,7 +79,33 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseFieldID": "drawDirectionsOrderSmallClaimsAdditionalDirections",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseFieldID": "orderType",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "orderTypeTrialAdditionalDirections",
     "AccessControl": [
       {
         "UserRoles": [

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -40,6 +40,18 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "drawDirectionsOrderSmallClaimsAdditionalDirections",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "ClaimsTrack",
+    "PageDisplayOrder": 2,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N",
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"Yes\" AND drawDirectionsOrderSmallClaims=\"Yes\""
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "claimsTrack",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY",
@@ -48,7 +60,7 @@
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
     "CaseEventFieldLabel": "What track are you allocating the claim to?",
-    "FieldShowCondition": "drawDirectionsOrderRequired = \"No\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"No\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -60,7 +72,7 @@
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "claimsTrack = \"smallClaimsTrack\" AND drawDirectionsOrderRequired = \"No\""
+    "FieldShowCondition": "claimsTrack=\"smallClaimsTrack\" AND drawDirectionsOrderRequired=\"No\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -72,7 +84,7 @@
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "claimsTrack = \"fastTrack\" AND drawDirectionsOrderRequired = \"No\""
+    "FieldShowCondition": "claimsTrack=\"fastTrack\" AND drawDirectionsOrderRequired=\"No\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -84,7 +96,19 @@
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "drawDirectionsOrderSmallClaims = \"No\" AND drawDirectionsOrderRequired=\"Yes\""
+    "PageShowCondition": "drawDirectionsOrderSmallClaims=\"No\" AND drawDirectionsOrderRequired=\"Yes\""
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "  orderTypeTrialAdditionalDirections",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL",
+    "PageID": "OrderType",
+    "PageDisplayOrder": 3,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N",
+    "FieldShowCondition": "drawDirectionsOrderSmallClaims=\"No\" AND drawDirectionsOrderRequired=\"Yes\" AND orderType=\"DECIDE_DAMAGES\""
   },
   {
     "CaseTypeID": "CIVIL",

--- a/ccd-definition/CaseField/CaseField-SDO-nonprod.json
+++ b/ccd-definition/CaseField/CaseField-SDO-nonprod.json
@@ -47,10 +47,26 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "drawDirectionsOrderSmallClaimsAdditionalDirections",
+    "Label": "Select additional directions for Small Claims Track, if any ",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "DrawDirectionsOrderSmallClaimsAdditionalDirections",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "orderType",
     "Label": "What order would you like to make?",
     "FieldType": "FixedRadioList",
     "FieldTypeParameter": "OrderType",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "orderTypeTrialAdditionalDirections",
+    "Label": "Select additional directions, if any ",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "OrderTypeTrialAdditionalDirections",
     "SecurityClassification": "Public"
   },
   {

--- a/ccd-definition/FixedLists/DrawDirectionsOrderSmallClaimsAdditionalDirections-SDO-nonprod.json
+++ b/ccd-definition/FixedLists/DrawDirectionsOrderSmallClaimsAdditionalDirections-SDO-nonprod.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ID": "DrawDirectionsOrderSmallClaimsAdditionalDirections",
+    "ListElementCode": "DrawDirectionsOrderSmallClaimsAdditionalDirectionsCreditHire",
+    "ListElement": "Credit Hire",
+    "DisplayOrder": 1
+  },
+  {
+    "ID": "DrawDirectionsOrderSmallClaimsAdditionalDirections",
+    "ListElementCode": "DrawDirectionsOrderSmallClaimsAdditionalDirectionsTrafficAccident",
+    "ListElement": "Road Traffic Accident",
+    "DisplayOrder": 2
+  }
+]

--- a/ccd-definition/FixedLists/OrderTypeTrialAdditionalDirections-SDO-nonprod.json
+++ b/ccd-definition/FixedLists/OrderTypeTrialAdditionalDirections-SDO-nonprod.json
@@ -1,0 +1,45 @@
+[
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsBuildingDispute",
+    "ListElement": "Building Dispute",
+    "DisplayOrder": 1
+
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsClinicalNegligence",
+    "ListElement": "Clinical Negligence",
+    "DisplayOrder": 2
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsCreditHire",
+    "ListElement": "Credit Hire",
+    "DisplayOrder": 3
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsEmployersLiability",
+    "ListElement": "Employers Liability",
+    "DisplayOrder": 4
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsHousingDisrepair",
+    "ListElement": "Housing Disrepair",
+    "DisplayOrder": 5
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsPersonalInjury",
+    "ListElement": "Personal Injury",
+    "DisplayOrder": 6
+  },
+  {
+    "ID": "OrderTypeTrialAdditionalDirections",
+    "ListElementCode": "OrderTypeTrialAdditionalDirectionsRoadTrafficAccident",
+    "ListElement": "Road Traffic Accident",
+    "DisplayOrder": 7
+  }
+]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1430
https://tools.hmcts.net/jira/browse/CIV-1431

### Change description ###
This PR adds additional directions to some of the screens within the SDO flow.

![screen 3b](https://user-images.githubusercontent.com/94545342/160112626-c04689dc-361e-43d6-9025-4da5c2de17c9.PNG)

![screen 2e](https://user-images.githubusercontent.com/94545342/160112619-8b0370a0-8132-442c-9ab0-c56d62b1564d.PNG)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```