### PR TITLE
Feat/civ 757 civ 115 civ 1111

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldDJ.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldDJ.json
@@ -199,25 +199,7 @@
   },
   {
     "CaseTypeID": "CIVIL",
-    "CaseFieldID": "detailsOfDirectionDisposal",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "caseworker-civil-solicitor"
-        ],
-        "CRUD": "CRUD"
-      },
-      {
-        "UserRoles": [
-          "caseworker-civil-admin"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "CIVIL",
-    "CaseFieldID": "detailsOfDirectionTrial",
+    "CaseFieldID": "detailsOfDirection",
     "AccessControl": [
       {
         "UserRoles": [
@@ -269,6 +251,4 @@
       }
     ]
   }
-
-
 ]

--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldDJspec.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldDJspec.json
@@ -19,6 +19,24 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseFieldID": "bothDefendantsSpec",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseFieldID": "CPRCertifySpec",
     "AccessControl": [
       {
@@ -38,6 +56,60 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseFieldID": "CPRConfirmationSpec",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "CPRCertifySpecTwoDefendant",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "CPRConfirmationSpecTwoDefendant",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "currentDefendant",
     "AccessControl": [
       {
         "UserRoles": [

--- a/ccd-definition/CaseEventToFields/DefaultJudgmentDJ.json
+++ b/ccd-definition/CaseEventToFields/DefaultJudgmentDJ.json
@@ -56,8 +56,7 @@
     "PageID": "showcertifystatement1",
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "Y",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/hearingTypeSelection"
+    "ShowSummaryChangeOption": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -69,8 +68,7 @@
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "defendantDetails=\"Both\"",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/hearingTypeSelection"
+    "FieldShowCondition": "defendantDetails=\"Both\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -135,27 +133,14 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "DEFAULT_JUDGEMENT",
-    "CaseFieldID": "detailsOfDirectionDisposal",
+    "CaseFieldID": "detailsOfDirection",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "MANDATORY",
     "PageID": "HearingType",
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "hearingSelection=\"DISPOSAL_HEARING\"",
-    "RetainHiddenValue": "Y"
-  },
-  {
-    "CaseTypeID": "CIVIL",
-    "CaseEventID": "DEFAULT_JUDGEMENT",
-    "CaseFieldID": "detailsOfDirectionTrial",
-    "PageFieldDisplayOrder": 6,
-    "DisplayContext": "MANDATORY",
-    "PageID": "HearingType",
-    "PageDisplayOrder": 3,
-    "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "hearingSelection=\"TRIAL_HEARING\"",
+    "FieldShowCondition": "hearingSelection=\"DISPOSAL_HEARING\" OR hearingSelection=\"TRIAL_HEARING\"",
     "RetainHiddenValue": "Y"
   },
   {

--- a/ccd-definition/CaseEventToFields/DefaultJudgmentDJspec.json
+++ b/ccd-definition/CaseEventToFields/DefaultJudgmentDJspec.json
@@ -22,7 +22,21 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "CaseEventFieldLabel": "Against which Defendant are you requesting default judgment?",
-    "ShowSummaryChangeOption": "Y"
+    "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/showCertifyStatementSpec"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
+    "CaseFieldID": "bothDefendantsSpec",
+    "PageFieldDisplayOrder": 5,
+    "DisplayContext": "MANDATORY",
+    "PageID": "showCertifyStatementSpec",
+    "PageDisplayOrder": 2,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N",
+    "FieldShowCondition": "defendantDetailsSpec=\"DO_NOT_SHOW_IN_UI\"",
+    "PageLabel": "Do all of these statements apply to the Defendant?"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -34,7 +48,7 @@
     "PageDisplayOrder": 2,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageLabel": "Do all of these statements apply to the Defendant?"
+    "PageShowCondition": "bothDefendantsSpec=\"One\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -50,20 +64,57 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
-    "CaseFieldID": "partialPaymentLabel",
+    "CaseFieldID": "CPRCertifySpecTwoDefendant",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "showCertifyStatementSpecMultipleDefendant",
+    "PageDisplayOrder": 2,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N",
+    "PageLabel": "Do all of these statements apply to the Defendants?",
+    "PageShowCondition": "bothDefendantsSpec=\"Both Defendants\""
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
+    "CaseFieldID": "CPRConfirmationSpecTwoDefendant",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "MANDATORY",
+    "PageID": "showCertifyStatementSpecMultipleDefendant",
+    "PageDisplayOrder": 2,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "Y"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
+    "CaseFieldID": "currentDefendant",
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "READONLY",
     "PageID": "claimPartialPayment",
     "PageDisplayOrder": 3,
     "PageColumnNumber": 1,
-    "PageShowCondition": "CPRConfirmationSpec = \"Yes\"",
+    "ShowSummaryChangeOption": "N",
+    "RetainHiddenValue": "N",
+    "FieldShowCondition": "defendantDetailsSpec=\"DO_NOT_SHOW_IN_UI\""
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
+    "CaseFieldID": "partialPaymentLabel",
+    "PageFieldDisplayOrder": 2,
+    "DisplayContext": "READONLY",
+    "PageID": "claimPartialPayment",
+    "PageDisplayOrder": 3,
+    "PageColumnNumber": 1,
+    "PageShowCondition": "CPRConfirmationSpec = \"Yes\" OR CPRConfirmationSpecTwoDefendant = \"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
     "CaseFieldID": "partialPayment",
-    "PageFieldDisplayOrder": 2,
+    "PageFieldDisplayOrder": 3,
     "DisplayContext": "MANDATORY",
     "PageID": "claimPartialPayment",
     "PageDisplayOrder": 3,
@@ -74,7 +125,7 @@
     "CaseTypeID": "CIVIL",
     "CaseEventID": "DEFAULT_JUDGEMENT_SPEC",
     "CaseFieldID": "partialPaymentAmount",
-    "PageFieldDisplayOrder": 3,
+    "PageFieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY",
     "PageID": "claimPartialPayment",
     "PageDisplayOrder": 3,
@@ -93,7 +144,7 @@
     "PageDisplayOrder": 4,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "CPRConfirmationSpec = \"Yes\""
+    "PageShowCondition": "CPRConfirmationSpec = \"Yes\" OR CPRConfirmationSpecTwoDefendant = \"Yes\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -117,7 +168,7 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "CPRConfirmationSpec = \"Yes\"",
+    "PageShowCondition": "CPRConfirmationSpec = \"Yes\" OR CPRConfirmationSpecTwoDefendant = \"Yes\"",
     "FieldShowCondition": "repaymentSummaryLabel = \"DO_NOT_SHOW_IN_UI\""
   },
   {

--- a/ccd-definition/CaseField/CaseFieldDJ.json
+++ b/ccd-definition/CaseField/CaseFieldDJ.json
@@ -73,20 +73,13 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "hearingDirectionsLabel",
-    "Label": "## What directions would you like the court to give? \n You can use the court's standard directions as out here or you may set out your preferred directions",
+    "Label": "## What directions would you like the court to give?",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },
   {
     "CaseTypeID": "CIVIL",
-    "ID": "detailsOfDirectionDisposal",
-    "Label": "Draft order",
-    "FieldType": "TextArea",
-    "SecurityClassification": "Public"
-  },
-  {
-    "CaseTypeID": "CIVIL",
-    "ID": "detailsOfDirectionTrial",
+    "ID": "detailsOfDirection",
     "Label": "Draft order",
     "FieldType": "TextArea",
     "SecurityClassification": "Public"

--- a/ccd-definition/CaseField/CaseFieldDJspec.json
+++ b/ccd-definition/CaseField/CaseFieldDJspec.json
@@ -8,7 +8,21 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "bothDefendantsSpec",
+    "Label": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "CPRCertifySpec",
+    "Label": "* The time for responding to the claim has expired. \n* The Defendant has not responded to the claim. \n* There is no outstanding application by the Defendant to strike out the claim for summary judgment. \n* The Defendant has not satisfied the whole claim, including costs. \n* The Defendant has not filed an admission together with request for time to pay.\n\n",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "CPRCertifySpecTwoDefendant",
     "Label": "* The time for responding to the claim has expired. \n* The Defendant has not responded to the claim. \n* There is no outstanding application by the Defendant to strike out the claim for summary judgment. \n* The Defendant has not satisfied the whole claim, including costs. \n* The Defendant has not filed an admission together with request for time to pay.\n\n",
     "FieldType": "Label",
     "SecurityClassification": "Public"
@@ -22,8 +36,23 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "CPRConfirmationSpecTwoDefendant",
+    "Label": "I certify that all of these statements are correct and apply to the defendants",
+    "FieldType": "YesOrNo",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "currentDefendant",
+    "Label": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public",
+    "_comment": "Used to populate title for partial payment, depending on whether both defendants were selected"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "partialPaymentLabel",
-    "Label": "## Has ${respondent1.partyName} paid some of the amount owed?",
+    "Label": "## ${currentDefendant}",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },

--- a/ccd-definition/CaseTypeTab/DefaultJudgmentDetailsDJ.json
+++ b/ccd-definition/CaseTypeTab/DefaultJudgmentDetailsDJ.json
@@ -20,18 +20,8 @@
     "TabID": "DefaultJudgment",
     "TabLabel": "Judgment",
     "TabDisplayOrder": 9,
-    "CaseFieldID": "detailsOfDirectionDisposal",
-    "TabFieldDisplayOrder": 3,
-    "FieldShowCondition": "hearingSelection=\"DISPOSAL_HEARING\""
-  },
-  {
-    "CaseTypeID": "CIVIL",
-    "TabID": "DefaultJudgment",
-    "TabLabel": "Judgment",
-    "TabDisplayOrder": 9,
-    "CaseFieldID": "detailsOfDirectionTrial",
-    "TabFieldDisplayOrder": 3,
-    "FieldShowCondition": "hearingSelection=\"TRIAL_HEARING\""
+    "CaseFieldID": "detailsOfDirection",
+    "TabFieldDisplayOrder": 3
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-757
https://tools.hmcts.net/jira/browse/CIV-1111
https://tools.hmcts.net/jira/browse/CIV-115

### Change description ###

Removed prepopulated court directions from default judgment damages journey

Add 1v2 options/display for 1v2 default judgments OCMC


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
