### PR TITLE
Case Taken Offline Schedular enhanced to cater for multiparty 1 v 2 (2 defendant solicitors)

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/systemUpdate.json
+++ b/ccd-definition/AuthorisationCaseEvent/systemUpdate.json
@@ -43,6 +43,12 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CASE_TAKEN_OFFLINE",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "CRU"

--- a/ccd-definition/CaseEvent/Camunda/NotificationEvents.json
+++ b/ccd-definition/CaseEvent/Camunda/NotificationEvents.json
@@ -183,6 +183,19 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CASE_TAKEN_OFFLINE",
+    "Name": "Email: Transfer claim offline",
+    "Description": "Notify respondent solicitor 2 for case taken offline",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "RetriesTimeoutURLAboutToSubmitEvent": 0
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE",
     "Name": "Email: Transfer claim offline",
     "Description": "Notify applicant solicitor 1 for case taken offline",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-2033

- Added NOTIFY_RESPONDENT_SOLICITOR2_FOR_CASE_TAKEN_OFFLINE notification event

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
