### PR TITLE
fix/NO-ISSUE 

### DIFF
--- a/ccd-definition/AuthorisationCaseField/systemUpdateLRspec.json
+++ b/ccd-definition/AuthorisationCaseField/systemUpdateLRspec.json
@@ -260,5 +260,11 @@
     "CaseFieldID": "applicant1DefenceResponseDocumentSpec",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "R"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "respondent2ClaimResponseTypeForSpec",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "R"
   }
 ]


### PR DESCRIPTION
### Change description ###
made respondent2ClaimResponseTypeForSpec available to Camunda, so it can access it on external tasks


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
