### PR TITLE
fix/CIV-2054 - Remove event summary field on BS Enter/Lift Events

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/BreathingSpaceLRspec.json
+++ b/ccd-definition/CaseEventToComplexTypes/BreathingSpaceLRspec.json
@@ -35,16 +35,8 @@
     "ID": "BreathingSpaceStartInfo",
     "CaseEventID": "ENTER_BREATHING_SPACE_SPEC",
     "CaseFieldID": "enterBreathing",
-    "ListElementCode": "event",
-    "FieldDisplayOrder": 5,
-    "DisplayContext": "OPTIONAL"
-  },
-  {
-    "ID": "BreathingSpaceStartInfo",
-    "CaseEventID": "ENTER_BREATHING_SPACE_SPEC",
-    "CaseFieldID": "enterBreathing",
     "ListElementCode": "eventDescription",
-    "FieldDisplayOrder": 6,
+    "FieldDisplayOrder": 5,
     "DisplayContext": "OPTIONAL"
   },
   {
@@ -59,16 +51,8 @@
     "ID": "BreathingSpaceLiftInfo",
     "CaseEventID": "LIFT_BREATHING_SPACE_SPEC",
     "CaseFieldID": "liftBreathing",
-    "ListElementCode": "event",
-    "FieldDisplayOrder": 2,
-    "DisplayContext": "OPTIONAL"
-  },
-  {
-    "ID": "BreathingSpaceLiftInfo",
-    "CaseEventID": "LIFT_BREATHING_SPACE_SPEC",
-    "CaseFieldID": "liftBreathing",
     "ListElementCode": "eventDescription",
-    "FieldDisplayOrder": 3,
+    "FieldDisplayOrder": 2,
     "DisplayContext": "OPTIONAL"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-2054


### Change description ###
- Remove "event summary" field on BS Enter/Lift Events

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
