### PR TITLE
feat/CIV-1879 LiP stays online following create claim

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField.json
@@ -4422,5 +4422,23 @@
         "CRUD": "RU"
       }
     ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "addLegalRepDeadline",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRUD"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
   }
 ]

--- a/ccd-definition/AuthorisationCaseField/staff.json
+++ b/ccd-definition/AuthorisationCaseField/staff.json
@@ -1007,5 +1007,11 @@
     "CaseFieldID": "respondent1GeneratedResponseDocument",
     "UserRole": "caseworker-civil-staff",
     "CRUD": "R"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "addLegalRepDeadline",
+    "UserRole": "caseworker-civil-staff",
+    "CRUD": "R"
   }
 ]

--- a/ccd-definition/AuthorisationCaseField/systemUpdate.json
+++ b/ccd-definition/AuthorisationCaseField/systemUpdate.json
@@ -406,5 +406,11 @@
     "CaseFieldID": "respondent1GeneratedResponseDocument",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "CR"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "addLegalRepDeadline",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "R"
   }
 ]

--- a/ccd-definition/CaseField/CaseField.json
+++ b/ccd-definition/CaseField/CaseField.json
@@ -2038,5 +2038,14 @@
     "Label": " ",
     "FieldType": "CaseDocument",
     "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "addLegalRepDeadline",
+    "Label": "Add Legal Rep Deadline",
+    "FieldType": "DateTime",
+    "SecurityClassification": "Public",
+    "_Definition":  "Add legal rep to case deadline",
+    "_Category":  "CIVIL"
   }
 ]

--- a/e2e/tests/api_tests/damages/api_1v1_test.js
+++ b/e2e/tests/api_tests/damages/api_1v1_test.js
@@ -5,65 +5,65 @@ const mpScenario = 'ONE_V_ONE';
 
 Feature('CCD 1v1 API test @api-unspec @api-multiparty @api-tests-1v1');
 
-// Scenario('Create claim', async ({I, api}) => {
-//   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);
-// });
-//
-// Scenario('HMCTS admin adds a case note to case', async ({I, api}) => {
-//   await api.addCaseNote(config.adminUser);
-// });
-//
-// Scenario('Amend claim documents', async ({I, api}) => {
-//   await api.amendClaimDocuments(config.applicantSolicitorUser);
-// });
-//
-// Scenario('Notify claim', async ({I, api}) => {
-//   await api.notifyClaim(config.applicantSolicitorUser);
-// });
-//
-// Scenario('Notify claim details', async ({I, api}) => {
-//   await api.notifyClaimDetails(config.applicantSolicitorUser);
-// });
-//
-// Scenario('Amend party details', async ({I, api}) => {
-//   await api.amendPartyDetails(config.adminUser);
-// });
-//
-// Scenario('Acknowledge claim', async ({I, api}) => {
-//   await api.acknowledgeClaim(config.defendantSolicitorUser, mpScenario);
-// });
-//
-// Scenario('Inform agreed extension date', async ({I, api}) => {
-//   await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario);
-// });
-//
-// Scenario('Defendant response', async ({I, api}) => {
-//   await api.defendantResponse(config.defendantSolicitorUser, mpScenario);
-// });
-//
-// Scenario('Claimant response', async ({I, api}) => {
-//   await api.claimantResponse(config.applicantSolicitorUser, mpScenario);
-// });
+Scenario('Create claim', async ({I, api}) => {
+  await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);
+});
+
+Scenario('HMCTS admin adds a case note to case', async ({I, api}) => {
+  await api.addCaseNote(config.adminUser);
+});
+
+Scenario('Amend claim documents', async ({I, api}) => {
+  await api.amendClaimDocuments(config.applicantSolicitorUser);
+});
+
+Scenario('Notify claim', async ({I, api}) => {
+  await api.notifyClaim(config.applicantSolicitorUser);
+});
+
+Scenario('Notify claim details', async ({I, api}) => {
+  await api.notifyClaimDetails(config.applicantSolicitorUser);
+});
+
+Scenario('Amend party details', async ({I, api}) => {
+  await api.amendPartyDetails(config.adminUser);
+});
+
+Scenario('Acknowledge claim', async ({I, api}) => {
+  await api.acknowledgeClaim(config.defendantSolicitorUser, mpScenario);
+});
+
+Scenario('Inform agreed extension date', async ({I, api}) => {
+  await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario);
+});
+
+Scenario('Defendant response', async ({I, api}) => {
+  await api.defendantResponse(config.defendantSolicitorUser, mpScenario);
+});
+
+Scenario('Claimant response', async ({I, api}) => {
+  await api.claimantResponse(config.applicantSolicitorUser, mpScenario);
+});
 
 Scenario('Create claim where respondent is litigant in person', async ({I, api}) => {
   await api.createClaimWithRespondentLitigantInPerson(config.applicantSolicitorUser);
 });
 
-// Scenario('Create claim where respondent solicitor is not registered in my hmcts', async ({I, api}) => {
-//   await api.createClaimWithRespondentSolicitorFirmNotInMyHmcts(config.applicantSolicitorUser);
-// });
-//
-// Scenario('Create claim and move it to caseman', async ({I, api}) => {
-//   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser);
-//   await api.moveCaseToCaseman(config.adminUser);
-// });
-//
-// // This will be enabled when PAY-3817 issue of two minutes is fixed
-// Scenario.skip('Resubmit claim after payment failure on PBA account ', async ({I, api}) => {
-//   await api.createClaimWithFailingPBAAccount(config.applicantSolicitorUser);
-//   await api.resubmitClaim(config.applicantSolicitorUser);
-// });
-//
-// AfterSuite(async  ({api}) => {
-//   await api.cleanUp();
-// });
+Scenario('Create claim where respondent solicitor is not registered in my hmcts', async ({I, api}) => {
+  await api.createClaimWithRespondentSolicitorFirmNotInMyHmcts(config.applicantSolicitorUser);
+});
+
+Scenario('Create claim and move it to caseman', async ({I, api}) => {
+  await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser);
+  await api.moveCaseToCaseman(config.adminUser);
+});
+
+// This will be enabled when PAY-3817 issue of two minutes is fixed
+Scenario.skip('Resubmit claim after payment failure on PBA account ', async ({I, api}) => {
+  await api.createClaimWithFailingPBAAccount(config.applicantSolicitorUser);
+  await api.resubmitClaim(config.applicantSolicitorUser);
+});
+
+AfterSuite(async  ({api}) => {
+  await api.cleanUp();
+});

--- a/e2e/tests/api_tests/damages/api_1v1_test.js
+++ b/e2e/tests/api_tests/damages/api_1v1_test.js
@@ -5,65 +5,65 @@ const mpScenario = 'ONE_V_ONE';
 
 Feature('CCD 1v1 API test @api-unspec @api-multiparty @api-tests-1v1');
 
-Scenario('Create claim', async ({I, api}) => {
-  await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);
-});
-
-Scenario('HMCTS admin adds a case note to case', async ({I, api}) => {
-  await api.addCaseNote(config.adminUser);
-});
-
-Scenario('Amend claim documents', async ({I, api}) => {
-  await api.amendClaimDocuments(config.applicantSolicitorUser);
-});
-
-Scenario('Notify claim', async ({I, api}) => {
-  await api.notifyClaim(config.applicantSolicitorUser);
-});
-
-Scenario('Notify claim details', async ({I, api}) => {
-  await api.notifyClaimDetails(config.applicantSolicitorUser);
-});
-
-Scenario('Amend party details', async ({I, api}) => {
-  await api.amendPartyDetails(config.adminUser);
-});
-
-Scenario('Acknowledge claim', async ({I, api}) => {
-  await api.acknowledgeClaim(config.defendantSolicitorUser, mpScenario);
-});
-
-Scenario('Inform agreed extension date', async ({I, api}) => {
-  await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario);
-});
-
-Scenario('Defendant response', async ({I, api}) => {
-  await api.defendantResponse(config.defendantSolicitorUser, mpScenario);
-});
-
-Scenario('Claimant response', async ({I, api}) => {
-  await api.claimantResponse(config.applicantSolicitorUser, mpScenario);
-});
+// Scenario('Create claim', async ({I, api}) => {
+//   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser, mpScenario);
+// });
+//
+// Scenario('HMCTS admin adds a case note to case', async ({I, api}) => {
+//   await api.addCaseNote(config.adminUser);
+// });
+//
+// Scenario('Amend claim documents', async ({I, api}) => {
+//   await api.amendClaimDocuments(config.applicantSolicitorUser);
+// });
+//
+// Scenario('Notify claim', async ({I, api}) => {
+//   await api.notifyClaim(config.applicantSolicitorUser);
+// });
+//
+// Scenario('Notify claim details', async ({I, api}) => {
+//   await api.notifyClaimDetails(config.applicantSolicitorUser);
+// });
+//
+// Scenario('Amend party details', async ({I, api}) => {
+//   await api.amendPartyDetails(config.adminUser);
+// });
+//
+// Scenario('Acknowledge claim', async ({I, api}) => {
+//   await api.acknowledgeClaim(config.defendantSolicitorUser, mpScenario);
+// });
+//
+// Scenario('Inform agreed extension date', async ({I, api}) => {
+//   await api.informAgreedExtension(config.defendantSolicitorUser, mpScenario);
+// });
+//
+// Scenario('Defendant response', async ({I, api}) => {
+//   await api.defendantResponse(config.defendantSolicitorUser, mpScenario);
+// });
+//
+// Scenario('Claimant response', async ({I, api}) => {
+//   await api.claimantResponse(config.applicantSolicitorUser, mpScenario);
+// });
 
 Scenario('Create claim where respondent is litigant in person', async ({I, api}) => {
   await api.createClaimWithRespondentLitigantInPerson(config.applicantSolicitorUser);
 });
 
-Scenario('Create claim where respondent solicitor is not registered in my hmcts', async ({I, api}) => {
-  await api.createClaimWithRespondentSolicitorFirmNotInMyHmcts(config.applicantSolicitorUser);
-});
-
-Scenario('Create claim and move it to caseman', async ({I, api}) => {
-  await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser);
-  await api.moveCaseToCaseman(config.adminUser);
-});
-
-// This will be enabled when PAY-3817 issue of two minutes is fixed
-Scenario.skip('Resubmit claim after payment failure on PBA account ', async ({I, api}) => {
-  await api.createClaimWithFailingPBAAccount(config.applicantSolicitorUser);
-  await api.resubmitClaim(config.applicantSolicitorUser);
-});
-
-AfterSuite(async  ({api}) => {
-  await api.cleanUp();
-});
+// Scenario('Create claim where respondent solicitor is not registered in my hmcts', async ({I, api}) => {
+//   await api.createClaimWithRespondentSolicitorFirmNotInMyHmcts(config.applicantSolicitorUser);
+// });
+//
+// Scenario('Create claim and move it to caseman', async ({I, api}) => {
+//   await api.createClaimWithRepresentedRespondent(config.applicantSolicitorUser);
+//   await api.moveCaseToCaseman(config.adminUser);
+// });
+//
+// // This will be enabled when PAY-3817 issue of two minutes is fixed
+// Scenario.skip('Resubmit claim after payment failure on PBA account ', async ({I, api}) => {
+//   await api.createClaimWithFailingPBAAccount(config.applicantSolicitorUser);
+//   await api.resubmitClaim(config.applicantSolicitorUser);
+// });
+//
+// AfterSuite(async  ({api}) => {
+//   await api.cleanUp();
+// });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1879


### Change description ###
Litigant in person / defendant defending themselves would not go offline
Changes for scheduler to take the case offline is going to be built in CIV-2090
Changes for camunda: https://github.com/hmcts/civil-camunda-bpmn-definition/pull/193
Changes for service: https://github.com/hmcts/civil-service/pull/954


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
