### PR TITLE
CIV-1840: prepopulate disposal hearing dates (2/2)

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
@@ -8,7 +8,7 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/version/V_1/about-to-submit",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "Y",
     "ShowEventNotes": "N",

--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -13,8 +13,7 @@
     "CaseFieldID": "disposalHearingJudgesRecital",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "Upon considering the claim Form and Particulars of Claim/statements of \ncase [and the directions questionnaires] \n\nIT IS ORDERED that:-"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingDisclosureOfDocuments",
@@ -30,8 +29,7 @@
     "CaseFieldID": "disposalHearingDisclosureOfDocuments",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The parties shall serve on each other copies of the documents upon \nwhich reliance is to be placed at the disposal hearing by 4pm on"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingDisclosureOfDocuments",
@@ -55,8 +53,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant shall serve on every other party the witness statements of \nall witnesses of fact on whose evidence reliance is to be placed by 4pm \non"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -72,8 +69,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The provisions of CPR 32.6 apply to such evidence."
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -81,8 +77,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input3",
     "FieldDisplayOrder": 5,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "Any application by the defendant/s pursuant to CPR 32.7 must be made by 4pm on"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -98,8 +93,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input4",
     "FieldDisplayOrder": 7,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "this field is too long to do in ccd,populate using civil-service instead"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -115,8 +109,7 @@
     "CaseFieldID": "disposalHearingMedicalEvidence",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant has permission to rely upon the written expert evidence \nserved with the Particulars of Claim to be disclosed by 4pm"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -132,8 +125,7 @@
     "CaseFieldID": "disposalHearingMedicalEvidence",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "and any associated correspondence and/or updating report disclosed \n not later than 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -189,8 +181,7 @@
     "CaseFieldID": "disposalHearingSchedulesOfLoss",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "If there is a claim for ongoing/future loss in the original schedule of \nlosses then the claimant must send an up to date schedule of loss to the \ndefendant by 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingSchedulesOfLoss",
@@ -206,8 +197,7 @@
     "CaseFieldID": "disposalHearingSchedulesOfLoss",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The defendant, in the event of challenge, must send an up to date \ncounter-schedule of loss to the claimant by 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingSchedulesOfLoss",
@@ -239,8 +229,7 @@
     "CaseFieldID": "disposalHearingStandardDisposalOrder",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "input"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingFinalDisposalHearing",
@@ -256,8 +245,7 @@
     "CaseFieldID": "disposalHearingFinalDisposalHearing",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "This claim be listed for final disposal before a Judge on the first available date after."
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingFinalDisposalHearing",
@@ -321,8 +309,7 @@
     "CaseFieldID": "disposalHearingBundle",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant must lodge at court at least 7 days before the disposal "
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingBundle",
@@ -354,8 +341,7 @@
     "CaseFieldID": "disposalHearingNotes",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "this field is too long to do in ccd,populate using civil-service instead"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingNotes",

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -119,7 +119,8 @@
     "PageID": "OrderDetails",
     "PageDisplayOrder": 4,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "N"
+    "ShowSummaryChangeOption": "N",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/order-details"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1840


### Change description ###
This PR is the CCD changes to CIV-1840. 
It removes some of the default values in the compelx types as they had to be populated by the civil-service instead based on reasons explained in the [civil-service PR](https://github.com/hmcts/civil-service/pull/957).
This should NOT be merged until the civil-service PR has been merged as it relies on code defined in that PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
