### PR TITLE
Civ 1849 disposal hearing populate fields (2/2)

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
@@ -131,7 +131,46 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingOrderAndHearingDetails",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseFieldID": "disposalHearingJudgesRecital",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingJudgementDeductionStatement",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingJudgementDeductionValue",
     "AccessControl": [
       {
         "UserRoles": [
@@ -262,6 +301,45 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseFieldID": "disposalHearingBundle",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingClaimSettling",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingCosts",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "disposalHearingApplicationsOrder",
     "AccessControl": [
       {
         "UserRoles": [

--- a/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
@@ -8,7 +8,7 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/version/V_1/about-to-submit",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "Y",
     "ShowEventNotes": "N",

--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -1,5 +1,45 @@
 [
   {
+    "ID": "JudgementSum",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "drawDirectionsOrder",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "JudgementSum",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "drawDirectionsOrder",
+    "ListElementCode": "judgementSum",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "OPTIONAL"
+  },
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingOrderAndHearingDetails",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingOrderAndHearingDetails",
+    "ListElementCode": "text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingOrderAndHearingDetails",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingJudgesRecital",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingJudgesRecital",
@@ -16,10 +56,50 @@
     "DisplayContext": "MANDATORY"
   },
   {
+    "ID": "DisposalHearingJudgementDeductionStatement",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionStatement",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionStatement",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionStatement",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionValue",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionValue",
+    "ListElementCode": "text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionValue",
+    "ListElementCode": "value",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingDisclosureOfDocuments",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingDisclosureOfDocuments",
-    "ListElementCode": "label",
+    "ListElementCode": "line1",
     "FieldDisplayOrder": 1,
     "DisplayContext": "READONLY"
   },
@@ -27,8 +107,16 @@
     "ID": "DisposalHearingDisclosureOfDocuments",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingDisclosureOfDocuments",
-    "ListElementCode": "input",
+    "ListElementCode": "label",
     "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingDisclosureOfDocuments",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingDisclosureOfDocuments",
+    "ListElementCode": "input",
+    "FieldDisplayOrder": 3,
     "DisplayContext": "MANDATORY"
   },
   {
@@ -36,8 +124,16 @@
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingDisclosureOfDocuments",
     "ListElementCode": "date",
-    "FieldDisplayOrder": 3,
+    "FieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY"
+  },
+  {
+    "ID": "DisposalHearingDisclosureOfDocuments",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingDisclosureOfDocuments",
+    "ListElementCode": "line2",
+    "FieldDisplayOrder": 5,
+    "DisplayContext": "READONLY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -96,6 +192,14 @@
     "DisplayContext": "MANDATORY"
   },
   {
+    "ID": "DisposalHearingWitnessOfFact",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingWitnessOfFact",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 8,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingMedicalEvidence",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingMedicalEvidence",
@@ -136,6 +240,14 @@
     "DisplayContext": "MANDATORY"
   },
   {
+    "ID": "DisposalHearingMedicalEvidence",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingMedicalEvidence",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 6,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingQuestionsToExperts",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingQuestionsToExperts",
@@ -165,6 +277,14 @@
     "CaseFieldID": "disposalHearingQuestionsToExperts",
     "ListElementCode": "text2",
     "FieldDisplayOrder": 4,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingQuestionsToExperts",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingQuestionsToExperts",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 5,
     "DisplayContext": "READONLY"
   },
   {
@@ -216,6 +336,14 @@
     "DisplayContext": "READONLY"
   },
   {
+    "ID": "DisposalHearingSchedulesOfLoss",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingSchedulesOfLoss",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 7,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingStandardDisposalOrder",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingStandardDisposalOrder",
@@ -230,6 +358,14 @@
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
     "DisplayContext": "MANDATORY"
+  },
+  {
+    "ID": "DisposalHearingStandardDisposalOrder",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingStandardDisposalOrder",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
   },
   {
     "ID": "DisposalHearingFinalDisposalHearing",
@@ -264,6 +400,14 @@
     "DisplayContext": "MANDATORY"
   },
   {
+    "ID": "DisposalHearingFinalDisposalHearing",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingFinalDisposalHearing",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 5,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingPreferredTelephone",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingPreferredTelephone",
@@ -293,6 +437,86 @@
     "CaseFieldID": "disposalHearingPreferredEmail",
     "ListElementCode": "email",
     "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingPreferredEmail",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingPreferredEmail",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingClaimSettling",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingClaimSettling",
+    "ListElementCode": "text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingClaimSettling",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingCosts",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingCosts",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingCosts",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingCosts",
+    "ListElementCode": "text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingCosts",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingCosts",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingApplicationsOrder",
+    "ListElementCode": "label",
+    "FieldDisplayOrder": 1,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingApplicationsOrder",
+    "ListElementCode": "text",
+    "FieldDisplayOrder": 2,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingApplicationsOrder",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 3,
     "DisplayContext": "READONLY"
   },
   {
@@ -328,6 +552,14 @@
     "DisplayContext": "READONLY"
   },
   {
+    "ID": "DisposalHearingBundle",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingBundle",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 5,
+    "DisplayContext": "READONLY"
+  },
+  {
     "ID": "DisposalHearingNotes",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingNotes",
@@ -350,5 +582,13 @@
     "ListElementCode": "date",
     "FieldDisplayOrder": 3,
     "DisplayContext": "MANDATORY"
+  },
+  {
+    "ID": "DisposalHearingNotes",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingNotes",
+    "ListElementCode": "line",
+    "FieldDisplayOrder": 4,
+    "DisplayContext": "READONLY"
   }
 ]

--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -13,8 +13,7 @@
     "CaseFieldID": "disposalHearingJudgesRecital",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "Upon considering the claim Form and Particulars of Claim/statements of \ncase [and the directions questionnaires] \n\nIT IS ORDERED that:-"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingDisclosureOfDocuments",
@@ -30,8 +29,7 @@
     "CaseFieldID": "disposalHearingDisclosureOfDocuments",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The parties shall serve on each other copies of the documents upon \nwhich reliance is to be placed at the disposal hearing by 4pm on"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingDisclosureOfDocuments",
@@ -55,8 +53,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant shall serve on every other party the witness statements of \nall witnesses of fact on whose evidence reliance is to be placed by 4pm \non"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -72,8 +69,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The provisions of CPR 32.6 apply to such evidence."
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -81,8 +77,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input3",
     "FieldDisplayOrder": 5,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "Any application by the defendant/s pursuant to CPR 32.7 must be made by 4pm on"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingWitnessOfFact",
@@ -98,8 +93,7 @@
     "CaseFieldID": "disposalHearingWitnessOfFact",
     "ListElementCode": "input4",
     "FieldDisplayOrder": 7,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "this field is too long to do in ccd,populate using civil-service instead"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -115,8 +109,7 @@
     "CaseFieldID": "disposalHearingMedicalEvidence",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant has permission to rely upon the written expert evidence \nserved with the Particulars of Claim to be disclosed by 4pm"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -132,8 +125,7 @@
     "CaseFieldID": "disposalHearingMedicalEvidence",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "and any associated correspondence and/or updating report disclosed \n not later than 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingMedicalEvidence",
@@ -189,8 +181,7 @@
     "CaseFieldID": "disposalHearingSchedulesOfLoss",
     "ListElementCode": "input1",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "If there is a claim for ongoing/future loss in the original schedule of \nlosses then the claimant must send an up to date schedule of loss to the \ndefendant by 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingSchedulesOfLoss",
@@ -206,8 +197,7 @@
     "CaseFieldID": "disposalHearingSchedulesOfLoss",
     "ListElementCode": "input2",
     "FieldDisplayOrder": 4,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The defendant, in the event of challenge, must send an up to date \ncounter-schedule of loss to the claimant by 4pm on the"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingSchedulesOfLoss",
@@ -239,8 +229,7 @@
     "CaseFieldID": "disposalHearingStandardDisposalOrder",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "input"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingFinalDisposalHearing",
@@ -256,8 +245,7 @@
     "CaseFieldID": "disposalHearingFinalDisposalHearing",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "This claim be listed for final disposal before a Judge on the first available date after."
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingFinalDisposalHearing",
@@ -321,8 +309,7 @@
     "CaseFieldID": "disposalHearingBundle",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "The claimant must lodge at court at least 7 days before the disposal "
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingBundle",
@@ -354,8 +341,7 @@
     "CaseFieldID": "disposalHearingNotes",
     "ListElementCode": "input",
     "FieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
-    "DefaultValue": "this field is too long to do in ccd,populate using civil-service instead"
+    "DisplayContext": "MANDATORY"
   },
   {
     "ID": "DisposalHearingNotes",

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -16,7 +16,7 @@
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "drawDirectionsOrder",
     "PageFieldDisplayOrder": 2,
-    "DisplayContext": "OPTIONAL",
+    "DisplayContext": "COMPLEX",
     "PageID": "SDO",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
@@ -125,6 +125,17 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingOrderAndHearingDetails",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "disposalHearingJudgesRecital",
     "PageFieldDisplayOrder": 2,
     "DisplayContext": "COMPLEX",
@@ -136,18 +147,31 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingDisclosureOfDocuments",
+    "CaseFieldID": "disposalHearingJudgementDeductionStatement",
+    "PageFieldDisplayOrder": 3,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N",
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"Yes\""
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingJudgementDeductionValue",
     "PageFieldDisplayOrder": 4,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "N"
+    "ShowSummaryChangeOption": "N",
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"Yes\" AND drawDirectionsOrder.judgementSum!=\"\""
   },
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingWitnessOfFact",
+    "CaseFieldID": "disposalHearingDisclosureOfDocuments",
     "PageFieldDisplayOrder": 5,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -158,7 +182,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingMedicalEvidence",
+    "CaseFieldID": "disposalHearingWitnessOfFact",
     "PageFieldDisplayOrder": 6,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -169,7 +193,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingQuestionsToExperts",
+    "CaseFieldID": "disposalHearingMedicalEvidence",
     "PageFieldDisplayOrder": 7,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -180,7 +204,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingSchedulesOfLoss",
+    "CaseFieldID": "disposalHearingQuestionsToExperts",
     "PageFieldDisplayOrder": 8,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -191,7 +215,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingStandardDisposalOrder",
+    "CaseFieldID": "disposalHearingSchedulesOfLoss",
     "PageFieldDisplayOrder": 9,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -202,7 +226,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingFinalDisposalHearing",
+    "CaseFieldID": "disposalHearingStandardDisposalOrder",
     "PageFieldDisplayOrder": 10,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -213,8 +237,8 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingPreferredTelephone",
-    "PageFieldDisplayOrder": 12,
+    "CaseFieldID": "disposalHearingFinalDisposalHearing",
+    "PageFieldDisplayOrder": 11,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
     "PageDisplayOrder": 5,
@@ -224,7 +248,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingPreferredEmail",
+    "CaseFieldID": "disposalHearingPreferredTelephone",
     "PageFieldDisplayOrder": 13,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -235,7 +259,7 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingBundle",
+    "CaseFieldID": "disposalHearingPreferredEmail",
     "PageFieldDisplayOrder": 14,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
@@ -246,8 +270,52 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "CREATE_SDO",
-    "CaseFieldID": "disposalHearingNotes",
+    "CaseFieldID": "disposalHearingBundle",
+    "PageFieldDisplayOrder": 15,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingClaimSettling",
+    "PageFieldDisplayOrder": 16,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingCosts",
+    "PageFieldDisplayOrder": 17,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingApplicationsOrder",
     "PageFieldDisplayOrder": 18,
+    "DisplayContext": "COMPLEX",
+    "PageID": "DisposalHearing",
+    "PageDisplayOrder": 5,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "disposalHearingNotes",
+    "PageFieldDisplayOrder": 19,
     "DisplayContext": "COMPLEX",
     "PageID": "DisposalHearing",
     "PageDisplayOrder": 5,

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -119,7 +119,8 @@
     "PageID": "OrderDetails",
     "PageDisplayOrder": 4,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "N"
+    "ShowSummaryChangeOption": "N",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/order-details"
   },
   {
     "CaseTypeID": "CIVIL",

--- a/ccd-definition/CaseField/CaseField-SDO-nonprod.json
+++ b/ccd-definition/CaseField/CaseField-SDO-nonprod.json
@@ -10,7 +10,6 @@
     "CaseTypeID": "CIVIL",
     "ID": "drawDirectionsOrder",
     "Label": " ",
-    "HintText": " ",
     "FieldType": "JudgementSum",
     "SecurityClassification": "Public"
   },
@@ -78,6 +77,13 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingOrderAndHearingDetails",
+    "Label": "Order and hearing details",
+    "FieldType": "DisposalHearingOrderAndHearingDetails",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "disposalHearingJudgesRecital",
     "Label": "Judge's recital",
     "FieldType": "DisposalHearingJudgesRecital",
@@ -85,8 +91,22 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingJudgementDeductionStatement",
+    "Label": " ",
+    "FieldType": "DisposalHearingJudgementDeductionStatement",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingJudgementDeductionValue",
+    "Label": " ",
+    "FieldType": "DisposalHearingJudgementDeductionValue",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "disposalHearingDisclosureOfDocuments",
-    "Label": "Disclosure of documents",
+    "Label": " ",
     "FieldType": "DisposalHearingDisclosureOfDocuments",
     "SecurityClassification": "Public"
   },
@@ -151,6 +171,27 @@
     "ID": "disposalHearingPreferredEmail",
     "Label": "Preferred email",
     "FieldType": "DisposalHearingPreferredEmail",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingClaimSettling",
+    "Label": "Claim settling",
+    "FieldType": "DisposalHearingClaimSettling",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingCosts",
+    "Label": "Costs",
+    "FieldType": "DisposalHearingCosts",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "disposalHearingApplicationsOrder",
+    "Label": "Applications to set aside, vary or stay this order",
+    "FieldType": "DisposalHearingApplicationsOrder",
     "SecurityClassification": "Public"
   },
   {

--- a/ccd-definition/ComplexTypes/DisposalHearingApplicationsOrder-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingApplicationsOrder-SDO-nonprod.json
@@ -1,0 +1,23 @@
+[
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "ListElementCode": "label",
+    "FieldType": "Label",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "ListElementCode": "text",
+    "FieldType": "Label",
+    "ElementLabel": "Because this order has been made without a hearing, the parties have the right to apply to have the order set aside, varied or stayed. A party making such an application must send or deliver the application to the court (together with any appropraite fee) to arrive within seven days of service of this order.",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingApplicationsOrder",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/DisposalHearingBundle-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingBundle-SDO-nonprod.json
@@ -27,5 +27,12 @@
     "FieldType": "Label",
     "ElementLabel": "a case summary should not exceed 500 words",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingBundle",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingClaimSettling-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingClaimSettling-SDO-nonprod.json
@@ -1,0 +1,23 @@
+[
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "ListElementCode": "label",
+    "FieldType": "Label",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "ListElementCode": "text",
+    "FieldType": "Label",
+    "ElementLabel": "Each party must inform the court immediately if the case is settled, whether or not it is then possible to file a draft consent order to give effect to their agreement",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingClaimSettling",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/DisposalHearingCosts-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingCosts-SDO-nonprod.json
@@ -1,20 +1,20 @@
 [
   {
-    "ID": "DisposalHearingPreferredEmail",
+    "ID": "DisposalHearingCosts",
     "ListElementCode": "label",
     "FieldType": "Label",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "DisposalHearingPreferredEmail",
-    "ListElementCode": "email",
-    "FieldType": "Text",
-    "ElementLabel": " ",
+    "ID": "DisposalHearingCosts",
+    "ListElementCode": "text",
+    "FieldType": "Label",
+    "ElementLabel": "Costs in the case",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "DisposalHearingPreferredEmail",
+    "ID": "DisposalHearingCosts",
     "ListElementCode": "line",
     "FieldType": "Label",
     "ElementLabel": "****",

--- a/ccd-definition/ComplexTypes/DisposalHearingDisclosureOfDocuments-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingDisclosureOfDocuments-SDO-nonprod.json
@@ -1,9 +1,16 @@
 [
   {
     "ID": "DisposalHearingDisclosureOfDocuments",
+    "ListElementCode": "line1",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingDisclosureOfDocuments",
     "ListElementCode": "label",
     "FieldType": "Label",
-    "ElementLabel": " ",
+    "ElementLabel": "## Disclosure of documents ##",
     "SecurityClassification": "Public"
   },
   {
@@ -18,6 +25,13 @@
     "ListElementCode": "date",
     "FieldType": "Date",
     "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingDisclosureOfDocuments",
+    "ListElementCode": "line2",
+    "FieldType": "Label",
+    "ElementLabel": "****",
     "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingFinalDisposalHearing-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingFinalDisposalHearing-SDO-nonprod.json
@@ -27,5 +27,12 @@
     "FieldTypeParameter": "DisposalHearingFinalDisposalHearingTimeEstimate",
     "ElementLabel": "The time estimate is",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingFinalDisposalHearing",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingJudgementDeductionStatement-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingJudgementDeductionStatement-SDO-nonprod.json
@@ -1,0 +1,16 @@
+[
+  {
+    "ID": "DisposalHearingJudgementDeductionStatement",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionStatement",
+    "ListElementCode": "label",
+    "FieldType": "Label",
+    "ElementLabel": "## There is a judgment for the claimant for an amount to be decided by the court ##",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/DisposalHearingJudgementDeductionValue-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingJudgementDeductionValue-SDO-nonprod.json
@@ -1,0 +1,23 @@
+[
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "ListElementCode": "label",
+    "FieldType": "Label",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "ListElementCode": "text",
+    "FieldType": "Label",
+    "ElementLabel": "Subject to a deduction of:",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingJudgementDeductionValue",
+    "ListElementCode": "value",
+    "FieldType": "Text",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/DisposalHearingMedicalEvidence-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingMedicalEvidence-SDO-nonprod.json
@@ -33,5 +33,12 @@
       "FieldType": "Date",
       "ElementLabel": " ",
       "SecurityClassification": "Public"
+    },
+    {
+      "ID": "DisposalHearingMedicalEvidence",
+      "ListElementCode": "line",
+      "FieldType": "Label",
+      "ElementLabel": "****",
+      "SecurityClassification": "Public"
     }
   ]

--- a/ccd-definition/ComplexTypes/DisposalHearingNotes-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingNotes-SDO-nonprod.json
@@ -19,5 +19,12 @@
     "FieldType": "Date",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingNotes",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingOrderAndHearingDetails-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingOrderAndHearingDetails-SDO-nonprod.json
@@ -1,0 +1,23 @@
+[
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "ListElementCode": "label",
+    "FieldType": "Label",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "ListElementCode": "text",
+    "FieldType": "Label",
+    "ElementLabel": "Warning: you must comply with the terms imposed upon you by this order otherwise your claim or the defence of it is liable to be struck out or some other sanction imposed. If you cannot comply you are expected to make formal application to the court before any deadline imposed upon you expires.",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingOrderAndHearingDetails",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/ComplexTypes/DisposalHearingPreferredTelephone-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingPreferredTelephone-SDO-nonprod.json
@@ -9,8 +9,8 @@
   {
     "ID": "DisposalHearingPreferredTelephone",
     "ListElementCode": "telephone",
-    "FieldType": "Label",
-    "ElementLabel": "to be prepopulated by civil-service",
+    "FieldType": "Text",
+    "ElementLabel": " ",
     "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingQuestionsToExperts-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingQuestionsToExperts-SDO-nonprod.json
@@ -26,5 +26,12 @@
     "FieldType": "Label",
     "ElementLabel": "Any such question shall be answered within 14 days of service.",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingQuestionsToExperts",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingSchedulesOfLoss-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingSchedulesOfLoss-SDO-nonprod.json
@@ -40,5 +40,12 @@
     "FieldType": "Label",
     "ElementLabel": "If there is a claim for future pecuniary loss and the parties have not already set out their case on periodical payments, then they must do so in the respective schedule and counter-schedule.",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingSchedulesOfLoss",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingStandardDisposalOrder-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingStandardDisposalOrder-SDO-nonprod.json
@@ -12,5 +12,12 @@
     "FieldType": "TextArea",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingStandardDisposalOrder",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/DisposalHearingWitnessOfFact-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/DisposalHearingWitnessOfFact-SDO-nonprod.json
@@ -47,5 +47,12 @@
     "FieldType": "TextArea",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "DisposalHearingWitnessOfFact",
+    "ListElementCode": "line",
+    "FieldType": "Label",
+    "ElementLabel": "****",
+    "SecurityClassification": "Public"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1849


### Change description ###
This PR includes the ccd changes needed to be able to prepopulate certain fields. 
It also includes the show conditions for the judgementvalue on the disposal hearing pages.

We also added a 'line' to the end of each section as per designs.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
