### PR TITLE
I have added validation for unregistered organisation for optional fi…

### DIFF
--- a/ccd-definition/ComplexTypes/SolicitorOrganisationDetails.json
+++ b/ccd-definition/ComplexTypes/SolicitorOrganisationDetails.json
@@ -4,7 +4,9 @@
     "ListElementCode": "email",
     "FieldType": "Text",
     "ElementLabel": "Email",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": 80,
+    "RegularExpression": "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$|^$"
   },
   {
     "ID": "SolicitorOrganisationDetails",
@@ -18,21 +20,24 @@
     "ListElementCode": "fax",
     "FieldType": "Text",
     "ElementLabel": "Fax",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": 24
   },
   {
     "ID": "SolicitorOrganisationDetails",
     "ListElementCode": "dx",
     "FieldType": "Text",
     "ElementLabel": "DX",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": 35
   },
   {
     "ID": "SolicitorOrganisationDetails",
     "ListElementCode": "phoneNumber",
     "FieldType": "Text",
     "ElementLabel": "Phone number",
-    "SecurityClassification": "Public"
+    "SecurityClassification": "Public",
+    "Max": 24
   },
   {
     "ID": "SolicitorOrganisationDetails",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-2322

While creating a claim where a respondent is represented by an unregistered organisation we need to enter in their details manually. This page is missing validation on fields such as email and phone number which can result invalid fields being entered resulting in rpa schema validation errors when taking the case offline

I have updated the validation on all fields.

**Does this PR introduce a breaking change?** (check one with "x")


```
[ ] Yes
[ x] No
```
