### PR TITLE
fix/CIV-2647 Remove respondent solicitor access until notified

### DIFF
--- a/ccd-definition/AuthorisationCaseState/AuthorisationCaseState.json
+++ b/ccd-definition/AuthorisationCaseState/AuthorisationCaseState.json
@@ -11,12 +11,6 @@
           "caseworker-civil-admin"
         ],
         "CRUD": "CRUD"
-      },
-      {
-        "UserRoles": [
-          "caseworker-civil-solicitor"
-        ],
-        "CRUD": "R"
       }
     ]
   },
@@ -67,12 +61,6 @@
           "caseworker-civil-admin"
         ],
         "CRUD": "CRUD"
-      },
-      {
-        "UserRoles": [
-          "caseworker-civil-solicitor"
-        ],
-        "CRUD": "R"
       }
     ]
   },
@@ -92,8 +80,7 @@
         "UserRoles": [
           "[RESPONDENTSOLICITORONE]",
           "[RESPONDENTSOLICITORONESPEC]",
-          "[RESPONDENTSOLICITORTWOSPEC]",
-          "caseworker-civil-solicitor"
+          "[RESPONDENTSOLICITORTWOSPEC]"
         ],
         "CRUD": "R"
       }

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -131,7 +131,6 @@ module.exports = {
     await waitForFinishedBusinessProcess(caseId);
     await assertCorrectEventsAreAvailableToUser(config.applicantSolicitorUser, 'CASE_ISSUED');
     await assertCorrectEventsAreAvailableToUser(config.adminUser, 'CASE_ISSUED');
-    // await assertCaseNotAvailableToUser(config.defendantSolicitorUser);
 
     //field is deleted in about to submit callback
     deleteCaseFields('applicantSolicitor1CheckEmail');
@@ -191,7 +190,6 @@ module.exports = {
     await waitForFinishedBusinessProcess(caseId);
     await assertCorrectEventsAreAvailableToUser(config.applicantSolicitorUser, 'PENDING_CASE_ISSUED');
     await assertCorrectEventsAreAvailableToUser(config.adminUser, 'PENDING_CASE_ISSUED');
-    // await assertCaseNotAvailableToUser(config.defendantSolicitorUser);
   },
 
   resubmitClaim: async (user) => {
@@ -207,7 +205,6 @@ module.exports = {
     await waitForFinishedBusinessProcess(caseId);
     await assertCorrectEventsAreAvailableToUser(config.applicantSolicitorUser, 'CASE_ISSUED');
     await assertCorrectEventsAreAvailableToUser(config.adminUser, 'PENDING_CASE_ISSUED');
-    // await assertCaseNotAvailableToUser(config.defendantSolicitorUser);
   },
 
   amendClaimDocuments: async (user) => {
@@ -243,7 +240,6 @@ module.exports = {
     await waitForFinishedBusinessProcess(caseId);
     await assertCorrectEventsAreAvailableToUser(config.applicantSolicitorUser, 'CASE_ISSUED');
     await assertCorrectEventsAreAvailableToUser(config.adminUser, 'CASE_ISSUED');
-    // await assertCaseNotAvailableToUser(config.defendantSolicitorUser);
   },
 
   notifyClaim: async (user, multipartyScenario) => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-2647


### Change description ###
- Remove civil-solicitor access for claim issued and pending claim issued - so only applicant solicitor can see the claim
- Updated api tests



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
