### PR TITLE
fix/CVE-2022-22978 and CVE-2020-0187

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,6 +257,11 @@ dependencies {
   functionalTestImplementation sourceSets.main.runtimeClasspath
 
   smokeTestImplementation sourceSets.main.runtimeClasspath
+
+  // prevent CVE-2020-0187
+  implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.67'
+  // prevent CVE-2022-22978
+  implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.6.4'
 }
 
 wrapper {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -82,4 +82,8 @@
     <packageUrl regex="true">^pkg:maven/org\.apache\.poi/poi\-ooxml\-schemas@.*$</packageUrl>
     <cve>CVE-2022-26336</cve>
   </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring-security-rsa@1\.0\.9\.RELEASE.*$</packageUrl>
+    <cve>CVE-2022-22978</cve>
+  </suppress>
  </suppressions>


### PR DESCRIPTION
### Change description ###
updated the versions of 2 dependencies to the nearest point they don't fail the check; suppressed another vulnerability because there is not a better version available yet.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
