### PR TITLE
Changed the ASSIGN_CASE_TO_APPLICANT_SOLICITOR1 business process event to use a submitted callback

### DIFF
--- a/ccd-definition/CaseEvent/Camunda/BusinessProcessEvents.json
+++ b/ccd-definition/CaseEvent/Camunda/BusinessProcessEvents.json
@@ -46,7 +46,7 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
-    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "N",
     "ShowEventNotes": "N"
   },


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-2159

We have an issue where we are assigning a role to the applicant solicitor but the supplementary data added to the case from the assign api call is getting overwritten when we return an about to submit event. Seems ccd caches case data when an event is triggered and it reapplies this cached data on an about to submit, resulting in lost data changes made through an api call.
A working solution for us was to change the assign to solicitor callback handler to use a submitted event only so we don't trigger another data change in ccd after assigning a case role.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
