### PR TITLE
civil-1939-civil-judge-role-authorization-pipeline-issues

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
@@ -7,7 +7,7 @@
       "UserRoles": [
         "caseworker-civil-admin",
         "caseworker-civil-solicitor",
-        "caseworker-civil-judge"
+        "judge-profile"
       ],
       "CRUD": "CRU"
       }

--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-SDO-nonprod.json
@@ -6,7 +6,8 @@
       {
       "UserRoles": [
         "caseworker-civil-admin",
-        "caseworker-civil-solicitor"
+        "caseworker-civil-solicitor",
+        "caseworker-civil-judge"
       ],
       "CRUD": "CRU"
       }

--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
@@ -358,7 +358,7 @@
         "UserRoles": [
           "caseworker-civil-admin",
           "caseworker-civil-solicitor",
-          "caseworker-civil-judge"
+          "judge-profile"
         ],
         "CRUD": "CRU"
       }

--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
@@ -357,7 +357,8 @@
       {
         "UserRoles": [
           "caseworker-civil-admin",
-          "caseworker-civil-solicitor"
+          "caseworker-civil-solicitor",
+          "caseworker-civil-judge"
         ],
         "CRUD": "CRU"
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-1939

### Change description ###
When we add civil-judgerole  to authorization configs, when QA creates a PR with the changes not excluding nonprod, the pipeline fails on data mapping and/or smoke tests due to the civil-judge role.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
