### PR TITLE
Update Chart.yaml

### DIFF
--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.2
+    version: 4.0.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 4.0.1
+    version: 4.0.2
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 4.0.2
+    version: 4.0.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-ccd/Chart.yaml
+++ b/charts/civil-ccd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for civil-ccd App
 name: civil-ccd
 home: https://github.com/hmcts/civil-ccd-definition
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: HMCTS Civil team
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-3717

### Change description ###
Chart Update to Java: 4.0.1

CFT are migrating to Traefik V2 to enable the clusters to be upgraded to AKS 1.23 before the end of this month, as Microsoft will not be supporting the current version we’re running in Production.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
