### PR TITLE
fix CIV-3209 bug

### DIFF
--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -794,7 +794,8 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -1149,7 +1150,8 @@
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-3209


### Change description ###
Fixes a bug where pressing previous didn't go to the previous screen but rather the screen before. This was because the previous screen was conditionally rendered but the value used for this condition was not being retained in case data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
