### PR TITLE
Civ 3209 sdo previous page bug new

### DIFF
--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -711,7 +711,7 @@
     "ListElementCode": "input3",
     "FieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY",
-    "EventHintText": "Number of witnesses (defendant), e.g. 4"
+    "EventHintText": "Number of witnesses (defendant), e.g. 4 "
   },
   {
     "ID": "SmallClaimsWitnessStatement",

--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -702,7 +702,7 @@
     "ListElementCode": "input2",
     "FieldDisplayOrder": 3,
     "DisplayContext": "MANDATORY",
-    "EventHintText": "Number of witnesses (claimant), e.g. 4 "
+    "EventHintText": "Number of witnesses (claimant), e.g. 4"
   },
   {
     "ID": "SmallClaimsWitnessStatement",

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -725,7 +725,8 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -1079,7 +1080,8 @@
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-3209


### Change description ###
Fixes a bug where pressing previous didn't go to the previous screen but rather the screen before. This was because the previous screen was conditionally rendered but the value used for this condition was not being retained in case data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
