### PR TITLE
CIV-3008 Changed SDO prepopulation callback from mid to about-to-start

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
+++ b/ccd-definition/CaseEvent/User/UserEvents-SDO-nonprod.json
@@ -8,12 +8,14 @@
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-start",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
     "CallBackURLSubmittedEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/submitted",
     "ShowSummary": "Y",
     "ShowEventNotes": "N",
     "EndButtonLabel": "Submit",
     "RetriesTimeoutAboutToStartEvent": 0,
-    "RetriesTimeoutURLAboutToSubmitEvent": 0
+    "RetriesTimeoutURLAboutToSubmitEvent": 0,
+    "RetriesTimeoutURLSubmittedEvent": 0
   }
 ]

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -9,8 +9,7 @@
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "CaseEventFieldLabel": "Do you wish to enter judgment for a sum of damages to be decided ?",
-    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/order-details"
+    "CaseEventFieldLabel": "Do you wish to enter judgment for a sum of damages to be decided ?"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-3008


### Change description ###
Switched the sdo prepopulation from a 'mid' to an 'about-to-start' callback to prevent recalling.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
