### PR TITLE
add sdo pdfs

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseField-SDO-nonprod.json
@@ -2192,5 +2192,20 @@
         "CRUD": "CRU"
       }
     ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "sdoOrderDocument",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "caseworker-civil-admin",
+          "caseworker-civil-solicitor",
+          "judge-profile",
+          "legal-adviser"
+        ],
+        "CRUD": "CRU"
+      }
+    ]
   }
 ]

--- a/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToComplexTypes/CreateSDO-SDO-nonprod.json
@@ -1410,6 +1410,22 @@
     "DisplayContext": "MANDATORY"
   },
   {
+    "ID": "FastTrackTrial",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "fastTrackTrial",
+    "ListElementCode": "label2",
+    "FieldDisplayOrder": 9,
+    "DisplayContext": "READONLY"
+  },
+  {
+    "ID": "FastTrackTrial",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "fastTrackTrial",
+    "ListElementCode": "type",
+    "FieldDisplayOrder": 10,
+    "DisplayContext": "MANDATORY"
+  },
+  {
     "ID": "FastTrackNotes",
     "CaseEventID": "CREATE_SDO",
     "CaseFieldID": "fastTrackNotes",

--- a/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
+++ b/ccd-definition/CaseEventToFields/CreateSDO-SDO-nonprod.json
@@ -124,7 +124,8 @@
     "PageDisplayOrder": 4,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "drawDirectionsOrderRequired=\"Yes\" AND drawDirectionsOrderSmallClaims=\"No\" AND orderType=\"DISPOSAL\""
+    "PageShowCondition": "drawDirectionsOrderRequired=\"Yes\" AND drawDirectionsOrderSmallClaims=\"No\" AND orderType=\"DISPOSAL\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/generate-sdo-order"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -725,7 +726,8 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -737,7 +739,8 @@
     "PageDisplayOrder": 5,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "setSmallClaimsFlag=\"Yes\""
+    "PageShowCondition": "setSmallClaimsFlag=\"Yes\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/generate-sdo-order"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -1079,7 +1082,8 @@
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\""
+    "FieldShowCondition": "drawDirectionsOrderRequired=\"DO NOT SHOW IN UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -1091,7 +1095,8 @@
     "PageDisplayOrder": 6,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "setFastTrackFlag=\"Yes\""
+    "PageShowCondition": "setFastTrackFlag=\"Yes\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/generate-sdo-order"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -1705,6 +1710,17 @@
     "DisplayContext": "COMPLEX",
     "PageID": "FastTrack",
     "PageDisplayOrder": 6,
+    "PageColumnNumber": 1,
+    "ShowSummaryChangeOption": "N"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_SDO",
+    "CaseFieldID": "sdoOrderDocument",
+    "PageFieldDisplayOrder": 1,
+    "DisplayContext": "READONLY",
+    "PageID": "OrderPreview",
+    "PageDisplayOrder": 7,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "N"
   }

--- a/ccd-definition/CaseField/CaseField-SDO-nonprod.json
+++ b/ccd-definition/CaseField/CaseField-SDO-nonprod.json
@@ -1085,5 +1085,12 @@
     "Label": "****",
     "FieldType": "Label",
     "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "sdoOrderDocument",
+    "Label": "View directions order",
+    "FieldType": "Document",
+    "SecurityClassification": "Public"
   }
 ]

--- a/ccd-definition/ComplexTypes/FastTrackTrial-SDO-nonprod.json
+++ b/ccd-definition/ComplexTypes/FastTrackTrial-SDO-nonprod.json
@@ -51,7 +51,22 @@
   {
     "ID": "FastTrackTrial",
     "ListElementCode": "input3",
-    "FieldType": "TextArea",
+    "FieldType": "Text",
+    "ElementLabel": " ",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "FastTrackTrial",
+    "ListElementCode": "label2",
+    "FieldType": "Label",
+    "ElementLabel": "#### Select bundle type",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "FastTrackTrial",
+    "ListElementCode": "type",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "FastTrackTrialBundleType",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   }

--- a/ccd-definition/ComplexTypes/SdoOrderDocument-sdo-nonprod.json
+++ b/ccd-definition/ComplexTypes/SdoOrderDocument-sdo-nonprod.json
@@ -1,0 +1,9 @@
+[
+  {
+    "ID": "SdoOrderDocument",
+    "ListElementCode": "sdoOrderDocument",
+    "FieldType": "Document",
+    "ElementLabel": "Document",
+    "SecurityClassification": "Public"
+  }
+]

--- a/ccd-definition/FixedLists/FastTrackTrialBundleType-SDO-nonprod.json
+++ b/ccd-definition/FixedLists/FastTrackTrialBundleType-SDO-nonprod.json
@@ -1,0 +1,20 @@
+[
+  {
+    "ID": "FastTrackTrialBundleType",
+    "ListElementCode": "DOCUMENTS",
+    "ListElement": "an indexed bundle of documents, with each page clearly numbered",
+    "DisplayOrder": 1
+  },
+  {
+    "ID": "FastTrackTrialBundleType",
+    "ListElementCode": "ELECTRONIC",
+    "ListElement": "an electronic bundle of digital documents",
+    "DisplayOrder": 2
+  },
+  {
+    "ID": "FastTrackTrialBundleType",
+    "ListElementCode": "SUMMARY",
+    "ListElement": "a case summary containing no more than 500 words",
+    "DisplayOrder": 3
+  }
+]

--- a/ccd-definition/FixedLists/SmallClaimsTimeEstimate-SDO-nonprod.json
+++ b/ccd-definition/FixedLists/SmallClaimsTimeEstimate-SDO-nonprod.json
@@ -7,8 +7,44 @@
   },
   {
     "ID": "SmallClaimsTimeEstimate",
-    "ListElementCode": "FIFTEEN_MINUTES",
-    "ListElement": "15 minutes",
+    "ListElementCode": "ONE_HOUR",
+    "ListElement": "One hour",
     "DisplayOrder": 2
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "ONE_AND_HALF_HOUR",
+    "ListElement": "One and half hour",
+    "DisplayOrder": 3
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "TWO_HOURS",
+    "ListElement": "Two hours",
+    "DisplayOrder": 4
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "TWO_AND_HALF_HOURS",
+    "ListElement": "Two and half hours",
+    "DisplayOrder": 5
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "THREE_HOURS",
+    "ListElement": "Three hours",
+    "DisplayOrder": 6
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "FOUR_HOURS",
+    "ListElement": "Four hours",
+    "DisplayOrder": 7
+  },
+  {
+    "ID": "SmallClaimsTimeEstimate",
+    "ListElementCode": "ONE_DAY",
+    "ListElement": "One day",
+    "DisplayOrder": 8
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-2093


### Change description ###
This PR updates small claims hearing to include more options as well as adds the callbacks to generate the pdfs for the SDO journey.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
