### PR TITLE
civil-4535-add-senior-tribunal-caseworker-role

### DIFF
--- a/ccd-definition/RoleToAccessProfiles/RoleToAccessProfiles-nonprod.json
+++ b/ccd-definition/RoleToAccessProfiles/RoleToAccessProfiles-nonprod.json
@@ -331,5 +331,14 @@
     "ReadOnly": "N",
     "Disabled": "F",
     "CaseAccessCategories": ""
+  },
+  {
+    "RoleName" : "senior-tribunal-caseworker",
+    "Authorisation": "",
+    "CaseTypeID": "CIVIL",
+    "AccessProfiles": "GS_profile,legal-adviser",
+    "ReadOnly": "N",
+    "Disabled": "F",
+    "CaseAccessCategories": ""
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-4535

### Change description ###

Due to the configuration around specific and challenged access, we need to add an additional access management role to the CCD configuration. The role that needs to be added is:

senior-tribunal-caseworker

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
