### PR TITLE
CIV-4845, fixing CVE supression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,7 @@ dependencies {
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.3'
   implementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.6'
   implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.3'
+  implementation "org.springframework.cloud:spring-cloud-starter-openfeign:2.2.10.RELEASE"
 
   constraints {
     implementation('org.apache.commons:commons-compress:1.21') {


### PR DESCRIPTION
In Spring Cloud OpenFeign 3.0.0 to 3.0.4, 2.2.0.RELEASE to 2.2.9.RELEASE, and older unsupported versions, applications using type-level `@RequestMapping`annotations over Feign client interfaces, can be involuntarily exposing endpoints corresponding to `@RequestMapping`-annotated interface methods.


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-4845


### Change description ###
In Spring Cloud OpenFeign 3.0.0 to 3.0.4, 2.2.0.RELEASE to 2.2.9.RELEASE, and older unsupported versions, applications using type-level `@RequestMapping`annotations over Feign client interfaces, can be involuntarily exposing endpoints corresponding to `@RequestMapping`-annotated interface methods.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
