### PR TITLE
switching on api tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,24 @@ task runDJFunctionalTests(type: Exec, description: 'Runs default judgement funct
   commandLine '/usr/bin/yarn', '--silent', 'test:e2e-dj'
 }
 
+task runDJTests(type: org.gradle.api.tasks.Exec, description: 'Runs DJ Api functional tests.') {
+  onlyIf {
+    return System.env.ENVIRONMENT == 'preview'
+  }
+  commandLine '/usr/bin/yarn', '--silent', 'test:api-dj'
+}
+
+task runApiTests(type: org.gradle.api.tasks.Exec, description: 'Runs Api tests.') {
+  commandLine '/usr/bin/yarn', '--silent', 'test:api-unspec'
+}
+
+task runSpecApiTests(type: org.gradle.api.tasks.Exec, description: 'Runs Spec functional tests.') {
+  onlyIf {
+    return System.env.ENVIRONMENT == 'preview'
+  }
+  commandLine '/usr/bin/yarn', '--silent', 'test:api-spec'
+}
+
 task demoEnvNonProdFeaturesEnabledFunctionalTests(type: Exec, description: 'Runs Non prod functional tests in demo') {
   commandLine '/usr/bin/yarn', '--silent', 'test:DemoFunctional'
 }
@@ -271,7 +289,7 @@ task smoke(description: 'Runs the smoke tests.') {
 }
 
 task functional(description: 'Runs the functional tests.') {
-  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, runSdoFunctionalTests, runSpecFunctionalTests, runUnspecFunctionalTests, runDJFunctionalTests))
+  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, runSdoFunctionalTests, runSpecFunctionalTests, runUnspecFunctionalTests, runDJFunctionalTests, runApiTests, runSpecApiTests, runDJTests))
 }
 
 project.tasks['sonarqube'].dependsOn test, jacocoTestReport


### PR DESCRIPTION
added new tasks for running api tests

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###
This PR is raised to enable api tests running on the pipeline so that developers will know any api test failures upfront rather than finding this in civil service or other repos which uses the latest assets of civil ccd to run the api tests. The api tests are stored in civil ccd so it would be better to have the PR pipeline running it


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
