### PR TITLE
removed CVE-2021-22118 from suppression file

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,7 +15,6 @@
     <cve>CVE-2017-18640</cve>
     <cve>CVE-2020-5398</cve>
     <cve>CVE-2018-15756</cve>
-
     <cve>CVE-2021-44228</cve>
     <cve>CVE-2021-44832</cve>
     <cve>CVE-2021-45046</cve>
@@ -35,7 +34,6 @@
     <cve>CVE-2021-22060</cve>
     <cve>CVE-2021-22096</cve>
     <cve>CVE-2022-22950</cve>
-
     <cve>CVE-2021-22119</cve>
     <cve>CVE-2022-22970</cve>
     <cve>CVE-2022-22971</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,7 +35,6 @@
     <cve>CVE-2021-22060</cve>
     <cve>CVE-2021-22096</cve>
     <cve>CVE-2022-22950</cve>
-    <cve>CVE-2021-22118</cve>
     <cve>CVE-2021-22119</cve>
     <cve>CVE-2022-22970</cve>
     <cve>CVE-2022-22971</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,7 +15,7 @@
     <cve>CVE-2017-18640</cve>
     <cve>CVE-2020-5398</cve>
     <cve>CVE-2018-15756</cve>
-    <cve>CVE-2021-42550</cve>
+
     <cve>CVE-2021-44228</cve>
     <cve>CVE-2021-44832</cve>
     <cve>CVE-2021-45046</cve>
@@ -35,6 +35,7 @@
     <cve>CVE-2021-22060</cve>
     <cve>CVE-2021-22096</cve>
     <cve>CVE-2022-22950</cve>
+
     <cve>CVE-2021-22119</cve>
     <cve>CVE-2022-22970</cve>
     <cve>CVE-2022-22971</cve>


### PR DESCRIPTION
[civil-ccd-definition] - Fix for CVE-2021-22118 and  CVE-2021-42550


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-4849
https://tools.hmcts.net/jira/browse/CIV-4850


### Change description ###
[civil-ccd-definition] - Fix for CVE-2021-22118 and  CVE-2021-42550


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
