### PR TITLE
CIV-4851: remove CVE-2022-22950

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,14 +29,13 @@
     <cve>CVE-2020-5412</cve>
     <cve>CVE-2019-3795</cve>
     <cve>CVE-2020-5408</cve>
-    <cve>CVE-2022-22950</cve>
     <cve>CVE-2021-22119</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-33915</cve>
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-31569</cve>
   </suppress>
-  <suppress>
+  <suppress until="2022-12-31">
     <notes>MEDIUM-jquery-suppressed at 21-02-2022</notes>
     <cve>CVE-2020-11022</cve>
     <cve>CVE-2020-11023</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,7 +35,7 @@
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-31569</cve>
   </suppress>
-  <suppress until="2022-12-31">
+  <suppress>
     <notes>MEDIUM-jquery-suppressed at 21-02-2022</notes>
     <cve>CVE-2020-11022</cve>
     <cve>CVE-2020-11023</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-4851

### Change description ###

- Removed the suppression CVE-2022-22950

- Spring dependencies are already updated, so no change there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
