### PR TITLE
feat/CIV-5605 fixed, document type value definition moved from GA to nonprod

### DIFF
--- a/ccd-definition/FixedLists/DocumentType-nonprod.json
+++ b/ccd-definition/FixedLists/DocumentType-nonprod.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ID": "DocumentType",
+    "ListElementCode": "SDO_ORDER",
+    "ListElement": "Standard Directions Order",
+    "DisplayOrder": 12
+  }
+]

--- a/ccd-definition/FixedLists/DocumentTypeGASpec.json
+++ b/ccd-definition/FixedLists/DocumentTypeGASpec.json
@@ -16,11 +16,5 @@
     "ListElementCode": "DIRECTION_ORDER",
     "ListElement": "Directions order",
     "DisplayOrder": 11
-  },
-  {
-    "ID": "DocumentType",
-    "ListElementCode": "SDO_ORDER",
-    "ListElement": "Standard Directions Order",
-    "DisplayOrder": 12
   }
 ]


### PR DESCRIPTION
### Change description ###
value for document type moved to nonprod as the rest of the changes of CIV-5605, https://github.com/hmcts/civil-ccd-definition/pull/1598/files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
