### PR TITLE
fixed CIV-5491, uploaded documents to be shown under "Claim Documents"

### DIFF
--- a/ccd-definition/ComplexTypes/ServedDocumentFiles.json
+++ b/ccd-definition/ComplexTypes/ServedDocumentFiles.json
@@ -55,5 +55,15 @@
     "FieldTypeParameter": "DocumentOrImageWithRegex",
     "ElementLabel": "Other documents",
     "SecurityClassification": "Public"
+  },
+  {
+    "ID": "ServedDocumentFiles",
+    "ListElementCode": "timelineEventUpload",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "Document",
+    "ElementLabel": "Claim timeline",
+    "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx",
+    "SecurityClassification": "Public",
+    "Max": 1
   }
 ]

--- a/charts/civil-ccd/values.preview.template.yaml
+++ b/charts/civil-ccd/values.preview.template.yaml
@@ -25,7 +25,7 @@ postgresql:
 
 java:
   applicationPort: 4000
-  image: 'hmctspublic.azurecr.io/civil/service:latest'
+  image: 'hmctspublic.azurecr.io/civil/service:pr-1728'
   imagePullPolicy: Always
   ingressHost: ${SERVICE_FQDN}
   keyVaults:


### PR DESCRIPTION
Investigation + Fix: Document getting uploaded but cannot be viewed on the Claim Document History


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-5491


### Change description ###
Investigation + Fix: Document getting uploaded but cannot be viewed on the Claim Document History



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
