### PR TITLE
Tolerate data setup failure

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/HighLevelDataSetupApp.java
@@ -80,4 +80,9 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
         // Do not create role assignments.
         BeftaUtils.defaultLog("Will NOT create role assignments!");
     }
+    
+    @Override
+    protected boolean shouldTolerateDataSetupFailure() {
+        return true;
+    }
 }


### PR DESCRIPTION
It is defaulted to false https://github.com/hmcts/befta-fw/blob/master/src/main/java/uk/gov/hmcts/befta/dse/ccd/DataLoaderToDefinitionStore.java#L178, this helps fixing issue on demo pipeline where pipeline fails when there is a timeout.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
