### PR TITLE
Remove Hearing of application option from HearingNoticeSelection list

### DIFF
--- a/ccd-definition/FixedLists/HearingNoticeSelection.json
+++ b/ccd-definition/FixedLists/HearingNoticeSelection.json
@@ -7,20 +7,14 @@
   },
   {
     "ID": "HearingNoticeSelection",
-    "ListElementCode": "HEARING_OF_APPLICATION",
-    "ListElement": "Hearing of application",
-    "DisplayOrder": 2
-  },
-  {
-    "ID": "HearingNoticeSelection",
     "ListElementCode": "FAST_TRACK_TRIAL",
     "ListElement": "Fast track trial date",
-    "DisplayOrder": 3
+    "DisplayOrder": 2
   },
   {
     "ID": "HearingNoticeSelection",
     "ListElementCode": "OTHER",
     "ListElement": "Other",
-    "DisplayOrder": 4
+    "DisplayOrder": 3
   }
 ]


### PR DESCRIPTION
### [Hearing Notice - Application Option removal](https://tools.hmcts.net/jira/browse/CIV-6060) ###



### Applications journey is no longer being completed via case progression due to data setup of application child cases. As such there is a requirement to comment out the application option from the work completed under [CIV-2215](https://tools.hmcts.net/jira/browse/CIV-2215) ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
