### PR TITLE
temporarily removing hearing error check

### DIFF
--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -461,10 +461,11 @@ module.exports = {
     await assertError('ConfirmDetails', defendantResponseData.invalid.ConfirmDetails.futureDateOfBirth,
       'The date entered cannot be in the future');
     await assertError('Experts', defendantResponseData.invalid.Experts.emptyDetails, 'Expert details required');
-    await assertError('Hearing', defendantResponseData.invalid.Hearing.past,
-      'The date cannot be in the past and must not be more than a year in the future');
-    await assertError('Hearing', defendantResponseData.invalid.Hearing.moreThanYear,
-      'The date cannot be in the past and must not be more than a year in the future');
+    // Uncommenting once civil service pr 1945 is merged
+    // await assertError('Hearing', defendantResponseData.invalid.Hearing.past,
+    //   'The date cannot be in the past and must not be more than a year in the future');
+    // await assertError('Hearing', defendantResponseData.invalid.Hearing.moreThanYear,
+    //   'The date cannot be in the past and must not be more than a year in the future');
 
     // In a 1v2 different solicitor case, when the first solicitor responds, civil service would not change the state
     // to AWAITING_APPLICANT_INTENTION until the all solicitor response.
@@ -515,10 +516,11 @@ module.exports = {
     await validateEventPages(claimantResponseData);
 
     await assertError('Experts', claimantResponseData.invalid.Experts.emptyDetails, 'Expert details required');
-    await assertError('Hearing', claimantResponseData.invalid.Hearing.past,
-      'The date cannot be in the past and must not be more than a year in the future');
-    await assertError('Hearing', claimantResponseData.invalid.Hearing.moreThanYear,
-      'The date cannot be in the past and must not be more than a year in the future');
+    // Uncommenting once civil service pr 1945 is merged
+    // await assertError('Hearing', claimantResponseData.invalid.Hearing.past,
+    //   'The date cannot be in the past and must not be more than a year in the future');
+    // await assertError('Hearing', claimantResponseData.invalid.Hearing.moreThanYear,
+    //   'The date cannot be in the past and must not be more than a year in the future');
 
     // This should be uncommented in ticket CIV-2493
     /*let validState = expectedCcdState || 'PROCEEDS_IN_HERITAGE_SYSTEM';
@@ -684,7 +686,7 @@ module.exports = {
     } else {
       await validateEventPages(data.REQUEST_DJ_ORDER('TRIAL_HEARING', mpScenario));
     }
-    
+
     await assertSubmittedEvent('CASE_PROGRESSION', {
       header: '',
       body: ''


### PR DESCRIPTION
### Change description ###
- removing hearing error check to aid in merging 
- https://github.com/hmcts/civil-ccd-definition/pull/1828
- https://github.com/hmcts/civil-service/pull/1945/files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
