### PR TITLE
Fix CCD Pr failures on go button

### DIFF
--- a/e2e/pages/caseView.page.js
+++ b/e2e/pages/caseView.page.js
@@ -13,18 +13,19 @@ module.exports = {
   },
   goButton: 'Go',
 
-  start: function (event) {
-    I.selectOption(this.fields.eventDropdown, event);
-    I.click(this.goButton);
-    I.click(this.goButton);
-    I.waitForElement(EVENT_TRIGGER_LOCATOR);
+  start: async function (event) {
+    await I.waitForElement(this.fields.eventDropdown, 10);
+    await I.selectOption(this.fields.eventDropdown, event);
+    await I.retryUntilExists(async () => {
+      await I.click(this.goButton);
+    }, EVENT_TRIGGER_LOCATOR);
   },
 
   async startEvent(event, caseId) {
       await waitForFinishedBusinessProcess(caseId);
       await I.retryUntilExists(async() => {
       await I.navigateToCaseDetails(caseId);
-      this.start(event);
+      await this.start(event);
     }, locate('.govuk-heading-l'));
   },
 


### PR DESCRIPTION
Go button is sometimes not clickable so adding retries on it.
The solution is working in general apps ccd def. This fix is based on it.