### PR TITLE
CIV-4304 show condition update for spec claims

### DIFF
--- a/ccd-definition/AuthorisationCaseField/EvidenceUpload-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/EvidenceUpload-nonprod.json
@@ -145,6 +145,25 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseFieldID": "caseProgAllocatedTrack",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "APP-SOL-UNSPEC-PROFILE",
+          "APP-SOL-SPEC-PROFILE"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "caseworker-civil-admin"
+        ],
+        "CRUD": "R"
+      }
+    ]
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseFieldID": "evidenceUploadText",
     "AccessControl": [
       {

--- a/ccd-definition/CaseEventToFields/EvidenceUpload-nonprod.json
+++ b/ccd-definition/CaseEventToFields/EvidenceUpload-nonprod.json
@@ -121,9 +121,9 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "EVIDENCE_UPLOAD_APPLICANT",
-    "CaseFieldID": "allocatedTrack",
+    "CaseFieldID": "caseProgAllocatedTrack",
     "PageFieldDisplayOrder": 2,
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "READONLY",
     "PageID": "EvidenceUpload",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
@@ -140,7 +140,7 @@
     "PageDisplayOrder": 2,
     "PageLabel": "Select the type of document you would like to upload",
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "allocatedTrack = \"FAST_CLAIM\" OR allocatedTrack = \"MULTI_CLAIM\""
+    "PageShowCondition": "caseProgAllocatedTrack = \"FAST_CLAIM\" OR caseProgAllocatedTrack = \"MULTI_CLAIM\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -262,7 +262,7 @@
     "PageDisplayOrder": 2,
     "ShowSummaryChangeOption": "N",
     "PageLabel": "Select the type of document you would like to upload",
-    "PageShowCondition": "allocatedTrack = \"SMALL_CLAIM\""
+    "PageShowCondition": "caseProgAllocatedTrack = \"SMALL_CLAIM\""
   },
   {
     "CaseTypeID": "CIVIL",
@@ -561,9 +561,9 @@
   {
     "CaseTypeID": "CIVIL",
     "CaseEventID": "EVIDENCE_UPLOAD_RESPONDENT",
-    "CaseFieldID": "allocatedTrack",
+    "CaseFieldID": "caseProgAllocatedTrack",
     "PageFieldDisplayOrder": 3,
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "READONLY",
     "PageID": "EvidenceUpload",
     "PageDisplayOrder": 1,
     "PageColumnNumber": 1,
@@ -580,7 +580,7 @@
     "PageDisplayOrder": 2,
     "PageLabel": "Select the type of document you would like to upload",
     "ShowSummaryChangeOption": "N",
-    "PageShowCondition": "allocatedTrack = \"FAST_CLAIM\" OR allocatedTrack = \"MULTI_CLAIM\"",
+    "PageShowCondition": "caseProgAllocatedTrack = \"FAST_CLAIM\" OR caseProgAllocatedTrack = \"MULTI_CLAIM\"",
     "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/createShowCondition"
   },
   {
@@ -704,7 +704,7 @@
     "ShowSummaryChangeOption": "N",
     "PageLabel": "Select the type of document you would like to upload",
     "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/createShowCondition",
-    "PageShowCondition": "allocatedTrack = \"SMALL_CLAIM\""
+    "PageShowCondition": "caseProgAllocatedTrack = \"SMALL_CLAIM\""
   },
   {
     "CaseTypeID": "CIVIL",

--- a/ccd-definition/CaseField/EvidenceUpload-nonprod.json
+++ b/ccd-definition/CaseField/EvidenceUpload-nonprod.json
@@ -64,6 +64,13 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "ID": "caseProgAllocatedTrack",
+    "Label":" ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "ID": "evidenceUploadText",
     "Label": "Check the order the court sent you for what documents you need to upload \n for your case. \n\n You cannot withdraw a document once you have uploaded it. If you want to \n add more information to something you have already uploaded, you can \n upload the document again and add a version number to the name, for \n example \"version 2\". \n\n The other parties will be able to see the documents you have uploaded, and \n you will be able to see their documents \n # Deadlines for uploading documents \n Check the order he court sent you for the deadlines for uploading your documents. If you upload a document after the deadline, you will have to apply to the court to use it at the hearing and the judge will decide if it can be accepted \n\n You do not have to upload all your documents at once. You can return to upload them later. \n # How to upload your evidence \n If a document has multiple pages, upload them as one file rather than multiple files. \n\n Before you upload the document, give it a name that tells the court what it is, for example \"Witness statement by Jane Smith\". \n\n Each document must be less than 100MB. You can upload the following file types: Word, Excel, PowerPoint, PDF, RTF, TXT, CSV, JPG, JPEG, PNG, BMP. TIF, TIFF.",
     "FieldType": "Label",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-4304

We were using allocatedTrack to determine which screen to show in evidence upload (small or fast track) this was not being set in spec cases, so neither option would show.

Have added new casedata item (caseProgAllocatedTrack) to store what the allocated track should be, and show conditions will now use that instead.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
