### PR TITLE
CIV-0000 - Using dbyccu version of definition processor till latest is fixed

### DIFF
--- a/bin/utils/process-definition.sh
+++ b/bin/utils/process-definition.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-definition_processor_version=latest
+definition_processor_version=dbyccu
 
 definition_dir=${1}
 definition_output_file=${2}


### PR DESCRIPTION
Using dbyccu version of definition processor tille latest is fixed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
