### PR TITLE
CIV-7645 - readded line for SDO to only be available through tasks

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEvents-SDO.json
+++ b/ccd-definition/CaseEvent/User/UserEvents-SDO.json
@@ -16,7 +16,8 @@
     "EndButtonLabel": "Submit",
     "RetriesTimeoutAboutToStartEvent": 0,
     "RetriesTimeoutURLAboutToSubmitEvent": 0,
-    "Publish": "Y"
+    "Publish": "Y",
+    "EventEnablingCondition": "detailsOfDirection = \"Only available through tasks\""
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### Change description ###
Readded line for SDO availability through tasks that was wrongfully removed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
