### PR TITLE
CIV-TASK Re-instate civil-screenshots.zip in AAT

### DIFF
--- a/bin/create-github-release.sh
+++ b/bin/create-github-release.sh
@@ -49,8 +49,7 @@ fi
 
 zip -r civil-ccd-definition.zip ccd-definition
 zip -r civil-e2e.zip e2e codecept.conf.js package.json steps.d.ts yarn.lock saucelabs.conf.js
-# 2023-04-19 - Below line commented as not working.
-# zip -r civil-screenshots.zip output
+zip -r civil-screenshots.zip test-results/functional
 ls -lash
 cp build/github-release/civil-ccd-aat.xlsx civil-ccd-aat.xlsx
 cp build/github-release/civil-ccd-prod.xlsx civil-ccd-prod.xlsx
@@ -61,8 +60,7 @@ uploadReleaseAsset civil-ccd-definition $releaseId civil-ccd-definition.zip
 uploadReleaseAsset civil-ccd-definition $releaseId civil-e2e.zip
 uploadReleaseAsset civil-ccd-definition $releaseId civil-ccd-aat.xlsx
 uploadReleaseAsset civil-ccd-definition $releaseId civil-ccd-prod.xlsx
-# 2023-04-19 - Below line commented as the corresponding zip command is not working.
-# uploadReleaseAsset civil-ccd-definition $releaseId civil-screenshots.zip
+uploadReleaseAsset civil-ccd-definition $releaseId civil-screenshots.zip
 
 rm civil-ccd-definition.zip
 rm civil-e2e.zip


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Re-instates the civil-screenshots.zip file for AAT functional test runs.

The file was temporarily disabled as it was being produced against the wrong directory. This should rectify the issue.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
