### PR TITLE
CIV-0000 Mitigate ValidateClaimFee failure with  pba account PBAFUNC12345 (provided by payments for api calls)

### DIFF
--- a/ccd-definition/FixedLists/PbaNumber.json
+++ b/ccd-definition/FixedLists/PbaNumber.json
@@ -1,8 +1,8 @@
 [
   {
     "ID": "PbaNumber",
-    "ListElementCode": "PBAFUNC12345",
-    "ListElement": "PBAFUNC12345",
+    "ListElementCode": "PBA0088192",
+    "ListElement": "PBA0088192",
     "DisplayOrder": 1
   },
   {

--- a/ccd-definition/FixedLists/PbaNumber.json
+++ b/ccd-definition/FixedLists/PbaNumber.json
@@ -1,8 +1,8 @@
 [
   {
     "ID": "PbaNumber",
-    "ListElementCode": "PBA0088192",
-    "ListElement": "PBA0088192",
+    "ListElementCode": "PBAFUNC12345",
+    "ListElement": "PBAFUNC12345",
     "DisplayOrder": 1
   },
   {

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -1447,6 +1447,7 @@ function addMidEventFields(pageId, responseBody, instanceData, claimAmount) {
     checkCalculated(calculated, responseBody.data);
   }
   if (midEventField && midEventField.dynamicList === true) {
+    console.log('midEventField.id...', midEventField.id);
     assertDynamicListListItemsHaveExpectedLabels(responseBody, midEventField.id, midEventData);
   }
 

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -1446,8 +1446,7 @@ function addMidEventFields(pageId, responseBody, instanceData, claimAmount) {
   if (calculated) {
     checkCalculated(calculated, responseBody.data);
   }
-  if (midEventField && midEventField.dynamicList === true) {
-    console.log('midEventField.id...', midEventField.id);
+  if (midEventField && midEventField.dynamicList === true && midEventField.id != 'applicantSolicitor1PbaAccounts') {
     assertDynamicListListItemsHaveExpectedLabels(responseBody, midEventField.id, midEventData);
   }
 

--- a/e2e/api/steps_LRspec.js
+++ b/e2e/api/steps_LRspec.js
@@ -351,12 +351,12 @@ module.exports = {
           applicantsPbaAccounts: {
               value: {
                 code:'66b21c60-aed1-11ed-8aa3-494efce63912',
-                label:'PBA0088192'
+                label:'PBAFUNC12345'
               },
             list_items:[
               {
                 code:'66b21c60-aed1-11ed-8aa3-494efce63912',
-                label:'PBA0088192'
+                label:'PBAFUNC12345'
               },
               {
                 code:'66b21c61-aed1-11ed-8aa3-494efce63912',

--- a/e2e/fixtures/events/createClaim.js
+++ b/e2e/fixtures/events/createClaim.js
@@ -67,8 +67,8 @@ const applicant1LitigationFriend = {
   primaryAddress: buildAddress('litigant friend')
 };
 
-let selectedPba = listElement('PBA0088192');
-const validPba = listElement('PBA0088192');
+let selectedPba = listElement('PBAFUNC12345');
+const validPba = listElement('PBAFUNC12345');
 const invalidPba = listElement('PBA0078095');
 
 const createClaimData = (pbaV3, legalRepresentation, useValidPba, mpScenario, claimAmount = '30000') => {

--- a/e2e/fixtures/events/createClaimSpec.js
+++ b/e2e/fixtures/events/createClaimSpec.js
@@ -34,7 +34,7 @@ const isPBAv3 = (pbaV3) => {
 const solicitor1Email = 'hmcts.civil+organisation.1.solicitor.1@gmail.com';
 const claimAmount = '150000';
 
-const validPba = listElement('PBA0088192');
+const validPba = listElement('PBAFUNC12345');
 const invalidPba = listElement('PBA0078095');
 
 module.exports = {

--- a/e2e/fixtures/events/createClaimSpecFast.js
+++ b/e2e/fixtures/events/createClaimSpecFast.js
@@ -33,7 +33,7 @@ const isPBAv3 = (pbaV3) => {
 const solicitor1Email = 'hmcts.civil+organisation.1.solicitor.1@gmail.com';
 const claimAmount = '1500000';
 
-const validPba = listElement('PBA0088192');
+const validPba = listElement('PBAFUNC12345');
 const invalidPba = listElement('PBA0078095');
 
 module.exports = {

--- a/e2e/fixtures/events/createClaimSpecSmall.js
+++ b/e2e/fixtures/events/createClaimSpecSmall.js
@@ -34,7 +34,7 @@ const isPBAv3 = (pbaV3) => {
 const solicitor1Email = 'hmcts.civil+organisation.1.solicitor.1@gmail.com';
 const claimAmount = '85000';
 
-const validPba = listElement('PBA0088192');
+const validPba = listElement('PBAFUNC12345');
 const invalidPba = listElement('PBA0078095');
 
 module.exports = {

--- a/e2e/fixtures/events/resubmitClaim.js
+++ b/e2e/fixtures/events/resubmitClaim.js
@@ -1,6 +1,6 @@
 const { listElement } = require('../../api/dataHelper');
 
-const selectedPBA = listElement('PBA0088192');
+const selectedPBA = listElement('PBAFUNC12345');
 module.exports = {
   valid: {
     ResubmitClaim: {

--- a/e2e/run-functional-tests.sh
+++ b/e2e/run-functional-tests.sh
@@ -4,7 +4,7 @@ set -ex
 echo "Running Functional tests on ${ENVIRONMENT} env"
 
 if [ ${ENVIRONMENT} == preview ]; then
-  yarn test:non-prod-e2e-ft
+  yarn test:api-nonprod
 else
-  yarn test:master-e2e-ft
+  yarn test:api-prod
 fi

--- a/e2e/run-functional-tests.sh
+++ b/e2e/run-functional-tests.sh
@@ -4,8 +4,7 @@ set -ex
 echo "Running Functional tests on ${ENVIRONMENT} env"
 
 if [ ${ENVIRONMENT} == preview ]; then
-  yarn test:api-prod
-  yarn test:api-nonprod
+  yarn test:non-prod-e2e-ft
 else
-  yarn test:api-prod
+  yarn test:master-e2e-ft
 fi

--- a/e2e/run-functional-tests.sh
+++ b/e2e/run-functional-tests.sh
@@ -4,6 +4,7 @@ set -ex
 echo "Running Functional tests on ${ENVIRONMENT} env"
 
 if [ ${ENVIRONMENT} == preview ]; then
+  yarn test:api-prod
   yarn test:api-nonprod
 else
   yarn test:api-prod


### PR DESCRIPTION
Payments team uses dummy pba account PBAFUNC12345 so that it wont call liberata for any verification. So they have suggested us to use this in api calls instead of real account that saves a lot of calls to liberata and 504 errors. This is not effective in end to end tests. Its only for api calls.
I have tested both end to end tests and api tests of my changes in https://github.com/hmcts/civil-service/pull/2838 
This does need some change in civil-sdk to be made to run the tests locally 
