### PR TITLE
CIV-10602 testing

### DIFF
--- a/charts/civil-ccd/values.preview.template.yaml
+++ b/charts/civil-ccd/values.preview.template.yaml
@@ -1,5 +1,6 @@
 civil-service:
   java:
+    image: 'hmctspublic.azurecr.io/civil/service:pr-3299'
     keyVaults:
       civil:
         resourceGroup: civil

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -690,7 +690,6 @@ module.exports = {
     // workaround
     deleteCaseFields('applicantSolicitor1ClaimStatementOfTruth');
     deleteCaseFields('respondentResponseIsSame');
-    deleteCaseFields('respondent1DQDraftDirections');
 
     await apiRequest.setupTokens(user);
 

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -158,7 +158,7 @@ module.exports = {
     caseId = null;
     caseData = {};
     mpScenario = multipartyScenario;
-    const pbaV3 = true;
+    const pbaV3 = await checkToggleEnabled(PBAv3);
     let createClaimData = data.CREATE_CLAIM(mpScenario, claimAmount, pbaV3);
 
     //==============================================================
@@ -1323,7 +1323,7 @@ const assertSubmittedEvent = async (expectedState, submittedCallbackResponseCont
   assert.equal(responseBody.state, expectedState);
   if (hasSubmittedCallback) {
     assert.equal(responseBody.callback_response_status_code, 200);
-    //assert.include(responseBody.after_submit_callback_response.confirmation_header, submittedCallbackResponseContains.header);
+    assert.include(responseBody.after_submit_callback_response.confirmation_header, submittedCallbackResponseContains.header);
     if(submittedCallbackResponseContains.body) {
       assert.include(responseBody.after_submit_callback_response.confirmation_body, submittedCallbackResponseContains.body);
     }
@@ -1376,7 +1376,7 @@ const assertCorrectEventsAreAvailableToUser = async (user, state) => {
   if (['preview', 'demo'].includes(config.runningEnv)) {
     expect(caseForDisplay.triggers).to.deep.include.members(nonProdExpectedEvents[user.type][state]);
   } else {
-    //expect(caseForDisplay.triggers).to.deep.equalInAnyOrder(expectedEvents[user.type][state]);
+    expect(caseForDisplay.triggers).to.deep.equalInAnyOrder(expectedEvents[user.type][state]);
   }
 };
 

--- a/e2e/api/steps.js
+++ b/e2e/api/steps.js
@@ -158,7 +158,7 @@ module.exports = {
     caseId = null;
     caseData = {};
     mpScenario = multipartyScenario;
-    const pbaV3 = await checkToggleEnabled(PBAv3);
+    const pbaV3 = true;
     let createClaimData = data.CREATE_CLAIM(mpScenario, claimAmount, pbaV3);
 
     //==============================================================
@@ -690,6 +690,7 @@ module.exports = {
     // workaround
     deleteCaseFields('applicantSolicitor1ClaimStatementOfTruth');
     deleteCaseFields('respondentResponseIsSame');
+    deleteCaseFields('respondent1DQDraftDirections');
 
     await apiRequest.setupTokens(user);
 
@@ -1322,7 +1323,7 @@ const assertSubmittedEvent = async (expectedState, submittedCallbackResponseCont
   assert.equal(responseBody.state, expectedState);
   if (hasSubmittedCallback) {
     assert.equal(responseBody.callback_response_status_code, 200);
-    assert.include(responseBody.after_submit_callback_response.confirmation_header, submittedCallbackResponseContains.header);
+    //assert.include(responseBody.after_submit_callback_response.confirmation_header, submittedCallbackResponseContains.header);
     if(submittedCallbackResponseContains.body) {
       assert.include(responseBody.after_submit_callback_response.confirmation_body, submittedCallbackResponseContains.body);
     }
@@ -1375,7 +1376,7 @@ const assertCorrectEventsAreAvailableToUser = async (user, state) => {
   if (['preview', 'demo'].includes(config.runningEnv)) {
     expect(caseForDisplay.triggers).to.deep.include.members(nonProdExpectedEvents[user.type][state]);
   } else {
-    expect(caseForDisplay.triggers).to.deep.equalInAnyOrder(expectedEvents[user.type][state]);
+    //expect(caseForDisplay.triggers).to.deep.equalInAnyOrder(expectedEvents[user.type][state]);
   }
 };
 

--- a/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor1.js
+++ b/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor1.js
@@ -36,15 +36,6 @@ module.exports = {
             respondentSolicitor1Reference: 'Respondent reference'
           }
         },
-        Upload: {
-          respondent1ClaimResponseDocument: {
-            file: {
-              document_url: '${TEST_DOCUMENT_URL}',
-              document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-              document_filename: '${TEST_DOCUMENT_FILENAME}'
-            }
-          }
-        },
         FileDirectionsQuestionnaire: {
           respondent1DQFileDirectionsQuestionnaire: {
             explainedToClient: ['CONFIRM'],
@@ -127,13 +118,6 @@ module.exports = {
                 unavailableDateType: 'DATE_RANGE',
               })
             ]
-          }
-        },
-        DraftDirections: {
-          respondent1DQDraftDirections: {
-            document_url: '${TEST_DOCUMENT_URL}',
-            document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-            document_filename: '${TEST_DOCUMENT_FILENAME}'
           }
         },
         RequestedCourt: {

--- a/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor2.js
+++ b/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor2.js
@@ -30,15 +30,6 @@ module.exports = {
             respondentSolicitor1Reference: 'Respondent reference'
           }
         },
-        Upload: {
-          respondent2ClaimResponseDocument: {
-            file: {
-              document_url: '${TEST_DOCUMENT_URL}',
-              document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-              document_filename: '${TEST_DOCUMENT_FILENAME}'
-            }
-          }
-        },
         FileDirectionsQuestionnaire: {
           respondent2DQFileDirectionsQuestionnaire: {
             explainedToClient: ['CONFIRM'],

--- a/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor2.js
+++ b/e2e/fixtures/events/1v2DifferentSolicitorEvents/defendantResponse_Solicitor2.js
@@ -114,13 +114,6 @@ module.exports = {
             ]
           }
         },
-        DraftDirections: {
-          respondent2DQDraftDirections: {
-            document_url: '${TEST_DOCUMENT_URL}',
-            document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-            document_filename: '${TEST_DOCUMENT_FILENAME}'
-          }
-        },
         RequestedCourt: {
           respondent2DQRequestedCourt: {
             responseCourtLocations: {

--- a/e2e/fixtures/events/1v2SameSolicitorEvents/defendantResponse_sameSolicitor.js
+++ b/e2e/fixtures/events/1v2SameSolicitorEvents/defendantResponse_sameSolicitor.js
@@ -39,15 +39,6 @@ module.exports = {
           respondent1ClaimResponseType: 'FULL_DEFENCE',
           multiPartyResponseTypeFlags: 'FULL_DEFENCE'
         },
-        Upload: {
-          respondent1ClaimResponseDocument: {
-            file: {
-              document_url: '${TEST_DOCUMENT_URL}',
-              document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-              document_filename: '${TEST_DOCUMENT_FILENAME}'
-            }
-          }
-        },
         FileDirectionsQuestionnaire: {
           respondent1DQFileDirectionsQuestionnaire: {
             explainedToClient: ['CONFIRM'],
@@ -130,13 +121,6 @@ module.exports = {
                 unavailableDateType: 'DATE_RANGE',
               })
             ]
-          }
-        },
-        DraftDirections: {
-          respondent1DQDraftDirections: {
-            document_url: '${TEST_DOCUMENT_URL}',
-            document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-            document_filename: '${TEST_DOCUMENT_FILENAME}'
           }
         },
         RequestedCourt: {

--- a/e2e/fixtures/events/2v1Events/defendantResponse_2v1.js
+++ b/e2e/fixtures/events/2v1Events/defendantResponse_2v1.js
@@ -27,15 +27,6 @@ module.exports = {
           respondent1ClaimResponseTypeToApplicant2: 'FULL_DEFENCE',
           multiPartyResponseTypeFlags: 'FULL_DEFENCE'
         },
-        Upload: {
-          respondent1ClaimResponseDocument: {
-            file: {
-              document_url: '${TEST_DOCUMENT_URL}',
-              document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-              document_filename: '${TEST_DOCUMENT_FILENAME}'
-            }
-          }
-        },
         FileDirectionsQuestionnaire: {
           respondent1DQFileDirectionsQuestionnaire: {
             explainedToClient: ['CONFIRM'],
@@ -118,13 +109,6 @@ module.exports = {
                 unavailableDateType: 'DATE_RANGE',
               })
             ]
-          }
-        },
-        DraftDirections: {
-          respondent1DQDraftDirections: {
-            document_url: '${TEST_DOCUMENT_URL}',
-            document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-            document_filename: '${TEST_DOCUMENT_FILENAME}'
           }
         },
         RequestedCourt: {

--- a/e2e/fixtures/events/defendantResponse.js
+++ b/e2e/fixtures/events/defendantResponse.js
@@ -118,13 +118,6 @@ module.exports = {
             ]
           }
         },
-        DraftDirections: {
-          respondent1DQDraftDirections: {
-            document_url: '${TEST_DOCUMENT_URL}',
-            document_binary_url: '${TEST_DOCUMENT_BINARY_URL}',
-            document_filename: '${TEST_DOCUMENT_FILENAME}'
-          }
-        },
         RequestedCourt: {
           respondent1DQRequestedCourt: {
             responseCourtLocations: {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-10602

Updated API test to remove document respondent1DQDraftDirections, as it now removed after respond to claim, as it would show as a duplicate in case file view. We now populate respondent1DQDraftDirections in respond to claim, as it is required to populate a preview, we then remove it again on submission 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
