### PR TITLE
CIV-10836 asssisted order cost bug

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationFinalOrders-nonprod.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationFinalOrders-nonprod.json
@@ -297,6 +297,22 @@
   },
   {
     "CaseTypeID": "CIVIL",
+    "CaseFieldID": "finalOrderCost",
+    "UserRoles": [
+      "judge-profile"
+    ],
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseFieldID": "finalOrderCostSecondaryLabel",
+    "UserRoles": [
+      "judge-profile"
+    ],
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "CIVIL",
     "CaseFieldID": "assistedOrderCostList",
     "UserRoles": [
       "judge-profile"


### PR DESCRIPTION
Cost title not showing in demo, have added authorisations for casefields finalOrderCost and finalOrderCostSecondaryLabel

https://tools.hmcts.net/jira/browse/CIV-10836


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
