### PR TITLE
CIV-10948 - Added and removed states from GENERATE_DIRECTIONS_ORDER

### DIFF
--- a/ccd-definition/CaseEvent/User/UserEventsCaseProg-nonprod.json
+++ b/ccd-definition/CaseEvent/User/UserEventsCaseProg-nonprod.json
@@ -100,7 +100,7 @@
     "ID": "GENERATE_DIRECTIONS_ORDER",
     "Name": "Make an order",
     "Description": "Make an order",
-    "PreConditionState(s)": "JUDICIAL_REFERRAL;CASE_PROGRESSION;HEARING_READINESS;PREPARE_FOR_HEARING_CONDUCT_HEARING;DECISION_OUTCOME",
+    "PreConditionState(s)": "CASE_PROGRESSION;HEARING_READINESS;PREPARE_FOR_HEARING_CONDUCT_HEARING;DECISION_OUTCOME;All_FINAL_ORDERS_ISSUED",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-start",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-10948


### Change description ###
Removed judicial refferal & added All Final Orders issued as precondition for GENERATE_DIRECTIONS_ORDER.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```