### PR TITLE
CIV-10890 hint text within the 'Order' section

### DIFF
--- a/ccd-definition/CaseField/CaseFieldFinalOrders-nonprod.json
+++ b/ccd-definition/CaseField/CaseFieldFinalOrders-nonprod.json
@@ -158,6 +158,7 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "finalOrderOrderedThatText",
+    "HintText": "Please insert paragraph numbers before each term of the Order as you wish them to appear, as they will not be automatically generated",
     "Label": " ",
     "FieldType": "TextArea",
     "SecurityClassification": "Public",
@@ -394,6 +395,7 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "freeFormOrderedTextArea",
+    "HintText": "Please insert paragraph numbers before each term of the Order as you wish them to appear, as they will not be automatically generated",
     "Label": " ",
     "FieldType": "TextArea",
     "SecurityClassification": "Public",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-10890


### Change description ###
the following hint text appears beneath the 'The court orders that:' section: 'Please insert paragraph numbers before each term of the Order as you wish them to appear, as they will not be automatically generated'


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
