### PR TITLE
CIV-0000 fix to retain each element of a complex type

### DIFF
--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceDocumentType.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceDocumentType.json
@@ -6,7 +6,9 @@
     "ElementLabel": "Type of document",
     "HintText": "For example, contract, invoice, receipt, email, text message, photo, social media message",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentType",
@@ -15,7 +17,9 @@
     "ElementLabel": "Date document was issued or message was sent",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentType",
@@ -25,7 +29,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentType",
@@ -34,6 +40,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "documentUpload = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "documentUpload = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceDocumentTypeWithName.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceDocumentTypeWithName.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Witness's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentTypeWithName",
@@ -14,7 +16,9 @@
     "ElementLabel": "Type of document",
     "HintText": "For example, contract, invoice, receipt, email, text message, photo, social media message",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentTypeWithName",
@@ -23,7 +27,9 @@
     "ElementLabel": "Date document was issued or message was sent",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentTypeWithName",
@@ -33,7 +39,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "typeOfDocument != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceDocumentTypeWithName",
@@ -42,6 +50,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "documentUpload = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "documentUpload = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert1.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert1.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Expert's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert1",
@@ -13,7 +15,9 @@
     "FieldType": "Text",
     "ElementLabel": "Field of expertise",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert1",
@@ -22,7 +26,9 @@
     "ElementLabel": "Date statement was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert1",
@@ -32,7 +38,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert1",
@@ -41,6 +49,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert2.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert2.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Experts' names",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert2",
@@ -13,7 +15,9 @@
     "FieldType": "Text",
     "ElementLabel": "Fields of expertise",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert2",
@@ -22,7 +26,9 @@
     "ElementLabel": "Date statement was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert2",
@@ -32,7 +38,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert2",
@@ -41,6 +49,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert3.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert3.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Expert's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert3",
@@ -13,7 +15,9 @@
     "FieldType": "Text",
     "ElementLabel": "Other party's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert3",
@@ -21,7 +25,9 @@
     "FieldType": "Text",
     "ElementLabel": "Questions for another party's expert",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert3",
@@ -30,7 +36,9 @@
     "ElementLabel": "Date questions were asked",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert3",
@@ -40,7 +48,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert3",
@@ -49,6 +59,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert4.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceExpert4.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Expert's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert4",
@@ -13,7 +15,9 @@
     "FieldType": "Text",
     "ElementLabel": "Other party's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert4",
@@ -21,7 +25,9 @@
     "FieldType": "Text",
     "ElementLabel": "Name of document with other party's questions",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert4",
@@ -30,7 +36,9 @@
     "ElementLabel": "Date statement was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert4",
@@ -40,7 +48,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "expertOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceExpert4",
@@ -49,6 +59,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "expertDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness1.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness1.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Witness's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness1",
@@ -14,7 +16,9 @@
     "ElementLabel": "Date statement was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness1",
@@ -24,7 +28,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness1",
@@ -33,6 +39,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness2.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness2.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Witness's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness2",
@@ -14,7 +16,9 @@
     "ElementLabel": "Date summary was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness2",
@@ -24,7 +28,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness2",
@@ -33,6 +39,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]

--- a/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness3.json
+++ b/ccd-definition/ComplexTypes/CaseProgression/UploadEvidenceWitness3.json
@@ -5,7 +5,9 @@
     "FieldType": "Text",
     "ElementLabel": "Witness's name",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness3",
@@ -14,7 +16,9 @@
     "ElementLabel": "Date statement was made",
     "HintText": "For example, 12/09/2022",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness3",
@@ -24,7 +28,9 @@
     "FieldType": "Document",
     "RegularExpression": ".pdf,.txt,.doc,.dot,.docx,.rtf,.xls,.xlt,.xla,.xlsx,.xltx,.xlsb,.ppt,.pot,.pps,.ppa,.pptx,.potx,.ppsx,.jpg,.jpeg,.bmp,.tif,.tiff,.png",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "N",
+    "FieldShowCondition": "witnessOptionName != \"DO_NOT_SHOW_IN_UI\"",
+    "RetainHiddenValue": "Y"
   },
   {
     "ID": "UploadEvidenceWitness3",
@@ -33,6 +39,7 @@
     "FieldType": "DateTime",
     "SecurityClassification": "Public",
     "Searchable": "N",
-    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\""
+    "FieldShowCondition": "witnessOptionDocument = \"DUMMY_VALUE_TO_HIDE_FIELD\"",
+    "RetainHiddenValue": "Y"
   }
 ]


### PR DESCRIPTION
Previously we were able to apply retainHiddenvalues to the caseeventtofields field, when it was referencing  a case field which itself referenced a complex type.

Has been noticed this is no longer working, we now retainHiddenvalues  on the actual elements of the complex type


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
