### PR TITLE
CIV-12094 CUI Response Docmosis changes 

### DIFF
--- a/e2e/fixtures/events/cui/defendantResponseCui.js
+++ b/e2e/fixtures/events/cui/defendantResponseCui.js
@@ -32,7 +32,24 @@ module.exports = {
 
           },
           respondent1MediationLiPResponse:{
-            mediationDisagreementLiP:'No',
+            isMediationEmailCorrect: 'No',
+            isMediationPhoneCorrect: 'No',
+            alternativeMediationEmail: 'test@test.com',
+            unavailableDatesForMediation: [
+              {
+                id: '8f76a758-733b-42c0-95b9-69b3ee2b7e6a',
+                value: {
+                  who: 'defendant',
+                  date: '2024-01-01',
+                  fromDate: '2024-01-01',
+                  unavailableDateType: 'SINGLE_DATE'
+                }
+              }
+            ],
+             alternativeMediationTelephone: '01632960001',
+             isMediationContactNameCorrect: 'No',
+             hasUnavailabilityNextThreeMonths: 'Yes',
+             alternativeMediationContactPerson: 'aaa'
           },
           respondent1DQExtraDetails:{
             wantPhoneOrVideoHearing:'No',


### PR DESCRIPTION
…n document generation

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-12094


### Change description ###

Currently when the defendant does their response they can opt to mediation. There answer appears on their response.

They will no longer be opting in or out of mediation so this section now needs to show the information provided on the mediation screens. (name, tel number, email, unavailable dates).

This PR has changes in the document template to include the fields that were newly added as a part of CARM Mediation.
Also checking with feature toggle to check the cases are created before CARM or after CARM release

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
