### PR TITLE
CIV-13363 Fix listing notes tab labels

### DIFF
--- a/ccd-definition/CaseField/CaseField.json
+++ b/ccd-definition/CaseField/CaseField.json
@@ -994,7 +994,7 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "applicant1DQFurtherInformation",
-    "Label": "Applicant 1 Further information",
+    "Label": "Claimant 1 Further information",
     "FieldType": "FurtherInformation",
     "SecurityClassification": "Public",
     "Searchable": "N"
@@ -2255,7 +2255,7 @@
   {
     "CaseTypeID": "CIVIL",
     "ID": "applicant2DQFurtherInformation",
-    "Label": "Applicant 2 Further information",
+    "Label": "Claimant 2 Further information",
     "FieldType": "FurtherInformation",
     "SecurityClassification": "Public",
     "Searchable": "N"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-13363

Fixed the casefields used in the listing notes tab to use the label Claimant instead of Applicant.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
