### PR TITLE
CIV-13752 Claimant LiP dashboard notifications: set aside after court error

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/systemUpdate-JO-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/systemUpdate-JO-nonprod.json
@@ -1,0 +1,8 @@
+[
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_DASHBOARD_NOTIFICATION_SET_ASIDE_JUDGEMENT_CLAIMANT",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
+  }
+]

--- a/ccd-definition/CaseEvent/Camunda/DashboardEventsDJ-JO-nonprod.json
+++ b/ccd-definition/CaseEvent/Camunda/DashboardEventsDJ-JO-nonprod.json
@@ -1,0 +1,18 @@
+[
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "CREATE_DASHBOARD_NOTIFICATION_SET_ASIDE_JUDGEMENT_CLAIMANT",
+    "Name": "DJ SA Defendant Notification",
+    "Description": "Create DJ Set aside Defendant Notification",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "Y",
+    "ShowEventNotes": "N",
+    "EndButtonLabel": "Submit",
+    "RetriesTimeoutAboutToStartEvent": 0,
+    "RetriesTimeoutURLAboutToSubmitEvent": 0,
+    "RetriesTimeoutURLSubmittedEvent": 0
+  }
+]


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CIV-13752](https://tools.hmcts.net/jira/browse/CIV-13752)


### Change description ###
Claimant LiP dashboard notifications: set aside after court error


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
