### PR TITLE
CIV-13780 Add elec doc + disclosure report to INT DQ - Claimant LR

### DIFF
--- a/ccd-definition/CaseEventToFields/ClaimantResponse.json
+++ b/ccd-definition/CaseEventToFields/ClaimantResponse.json
@@ -293,7 +293,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY",
     "PageID": "DisclosureOfElectronicDocuments",
-    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND allocatedTrack=\"MULTI_CLAIM\" AND applicantsProceedIntention = \"Yes\"",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND applicantsProceedIntention = \"Yes\" AND (allocatedTrack=\"MULTI_CLAIM\" OR allocatedTrack=\"INTERMEDIATE_CLAIM\")",
     "FieldShowCondition": "claimant2ResponseFlag=\"No\"",
     "ShowSummaryChangeOption": "Y"
   },
@@ -339,7 +339,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": "DisclosureReport",
-    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND allocatedTrack=\"MULTI_CLAIM\" AND claimType!=\"PERSONAL_INJURY\" AND applicantsProceedIntention = \"Yes\"",
+    "PageShowCondition": "respondent1ClaimResponseType=\"FULL_DEFENCE\" AND (allocatedTrack=\"MULTI_CLAIM\" OR allocatedTrack=\"INTERMEDIATE_CLAIM\") AND claimType!=\"PERSONAL_INJURY\" AND applicantsProceedIntention = \"Yes\"",
     "FieldShowCondition": "claimant2ResponseFlag=\"No\"",
     "ShowSummaryChangeOption": "Y"
   },

--- a/ccd-definition/CaseEventToFields/ClaimantResponseLRspec-CUI.json
+++ b/ccd-definition/CaseEventToFields/ClaimantResponseLRspec-CUI.json
@@ -855,7 +855,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY",
     "PageID": "DisclosureOfElectronicDocuments",
-    "PageShowCondition": "(responseClaimTrack =\"FAST_CLAIM\" OR responseClaimTrack =\"MULTI_CLAIM\") AND applicantDefenceResponseDocumentAndDQFlag =\"Yes\"",
+    "PageShowCondition": "responseClaimTrack !=\"SMALL_CLAIM\" AND applicantDefenceResponseDocumentAndDQFlag =\"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {
@@ -877,7 +877,7 @@
     "PageFieldDisplayOrder": 1,
     "DisplayContext": "COMPLEX",
     "PageID": "DisclosureReport",
-    "PageShowCondition": "(responseClaimTrack =\"FAST_CLAIM\" OR responseClaimTrack =\"MULTI_CLAIM\") AND applicantDefenceResponseDocumentAndDQFlag =\"Yes\"",
+    "PageShowCondition": "responseClaimTrack != \"SMALL_CLAIM\" AND applicantDefenceResponseDocumentAndDQFlag =\"Yes\"",
     "ShowSummaryChangeOption": "Y"
   },
   {

--- a/e2e/fixtures/events/claimantResponse.js
+++ b/e2e/fixtures/events/claimantResponse.js
@@ -126,19 +126,52 @@ module.exports = {
             }
           }
         } : {}),
+        ...(allocatedTrack === 'INTERMEDIATE_CLAIM' || allocatedTrack === 'MULTI_CLAIM' ? {
         DisclosureOfElectronicDocuments: {
           applicant1DQDisclosureOfElectronicDocuments: {
             reachedAgreement: 'No',
               agreementLikely: 'Yes'
-          }
+            },
+            ...(mpScenario === 'TWO_V_ONE' ? {
+              applicant2DQDisclosureOfElectronicDocuments: {
+                reachedAgreement: 'No',
+                agreementLikely: 'Yes'
         },
+            } : {})
+          }
+        } : {}),
         DisclosureOfNonElectronicDocuments: {
           applicant1DQDisclosureOfNonElectronicDocuments: {
             directionsForDisclosureProposed: 'Yes',
               standardDirectionsRequired: 'No',
               bespokeDirections: 'directions'
-          }
+          },
+          ...(mpScenario === 'TWO_V_ONE' ? {
+            applicant2DQDisclosureOfNonElectronicDocuments: {
+              directionsForDisclosureProposed: 'Yes',
+              standardDirectionsRequired: 'No',
+              bespokeDirections: 'directions'
+            },
+          } : {})
         },
+        ...(allocatedTrack === 'INTERMEDIATE_CLAIM' || allocatedTrack === 'MULTI_CLAIM' ? {
+          DisclosureReport: {
+            applicant1DQDisclosureReport:
+              {
+                disclosureFormFiledAndServed: "Yes",
+                disclosureProposalAgreed: "Yes",
+                draftOrderNumber: "012345"
+              },
+            ...(mpScenario === 'TWO_V_ONE' ? {
+              applicant2DQDisclosureReport:
+                {
+                  disclosureFormFiledAndServed: "Yes",
+                  disclosureProposalAgreed: "Yes",
+                  draftOrderNumber: "012345"
+          }
+            } : {})
+          }
+        } : {}),
         Experts: {
           applicant1DQExperts: {
             expertRequired: 'Yes',

--- a/e2e/fixtures/events/claimantResponseIntermediateClaimSpec.js
+++ b/e2e/fixtures/events/claimantResponseIntermediateClaimSpec.js
@@ -27,9 +27,21 @@ module.exports = {
               reasons: 'some important reasons'
             }
           },
+          DisclosureOfElectronicDocuments: {
+            applicant1DQDisclosureOfElectronicDocuments: {
+              reachedAgreement: 'Yes'
+            }
+          },
           DisclosureOfNonElectronicDocuments: {
             specApplicant1DQDisclosureOfNonElectronicDocuments: {
               bespokeDirections: 'directions'
+            }
+          },
+          DisclosureReport: {
+            applicant1DQDisclosureReport: {
+              disclosureFormFiledAndServed: 'Yes',
+              'disclosureProposalAgreed': 'Yes',
+              'draftOrderNumber': null
             }
           },
           Experts: {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-13780

- Ensured DisclosureOfElectronicDocuments, DisclosureOfElectronicDocuments and DisclosureReport pages display in claimant dq journey for spec/unspec claims when track is INTERMEDIATE_CLAIM.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
