### PR TITLE
CIV-13793 Claimant dashboard notifications judgment by admission issued LiP vs LiP

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/systemUpdate-R2-CUI-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/systemUpdate-R2-CUI-nonprod.json
@@ -232,5 +232,11 @@
     "CaseEventID": "CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC",
     "UserRole": "caseworker-civil-systemupdate",
     "CRUD": "CRU"
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "CaseEventID": "CREATE_DASHBOARD_NOTIFICATION_JUDGEMENT_BY_ADMISSION_CLAIMANT",
+    "UserRole": "caseworker-civil-systemupdate",
+    "CRUD": "CRU"
   }
 ]

--- a/ccd-definition/CaseEvent/Camunda/DashboardEvents-R2-CUI-nonprod.json
+++ b/ccd-definition/CaseEvent/Camunda/DashboardEvents-R2-CUI-nonprod.json
@@ -458,5 +458,18 @@
     "ShowSummary": "N",
     "ShowEventNotes": "N",
     "RetriesTimeoutURLAboutToSubmitEvent": 0
+  },
+  {
+    "CaseTypeID": "CIVIL",
+    "ID": "CREATE_DASHBOARD_NOTIFICATION_JUDGEMENT_BY_ADMISSION_CLAIMANT",
+    "Name": "Judgment Issued Claimant",
+    "Description": "Create dashboard notice for JO issued",
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "CallBackURLAboutToSubmitEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-submit",
+    "ShowSummary": "N",
+    "ShowEventNotes": "N",
+    "RetriesTimeoutURLAboutToSubmitEvent": 0
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

[CIV-13793 Claimant dashboard notifications judgment by admission issued LiP vs LiP](https://tools.hmcts.net/jira/browse/CIV-13793)

### Change description ###

Judgment by admission CCJ requested by Claimant. Dashboard notification is displayed to inform the Claimant LiP that a judgment by admission has been issued against the Defendant.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
