### PR TITLE
CIV-0000 Fix judge not able to see listing notes tab

### DIFF
--- a/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldLRspec.json
+++ b/ccd-definition/AuthorisationCaseField/AuthorisationCaseFieldLRspec.json
@@ -1969,7 +1969,8 @@
       {
         "UserRoles": [
           "caseworker-civil-admin",
-          "APP-SOL-SPEC-PROFILE"
+          "APP-SOL-SPEC-PROFILE",
+          "judge-profile"
         ],
         "CRUD": "R"
       }
@@ -3856,7 +3857,8 @@
       {
         "UserRoles": [
           "caseworker-civil-admin",
-          "APP-SOL-SPEC-PROFILE"
+          "APP-SOL-SPEC-PROFILE",
+          "judge-profile"
         ],
         "CRUD": "R"
       }


### PR DESCRIPTION
- Added judge read permissions to respondent1ClaimResponseTypeForSpec respondent2ClaimResponseTypeForSpec so they can have access to the listing notes tab on spec claims as its failed a tab show condition.


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
