### PR TITLE
CIV-15614 - Fix that makes obligationDate searchable in storedObligationDate

### DIFF
--- a/ccd-definition/ComplexTypes/StoredObligationData.json
+++ b/ccd-definition/ComplexTypes/StoredObligationData.json
@@ -21,7 +21,7 @@
     "FieldType": "Date",
     "ElementLabel": "Review date",
     "SecurityClassification": "Public",
-    "Searchable": "N"
+    "Searchable": "Y"
   },
   {
     "ID": "StoredObligationData",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-15614


### Change description ###
Make obligationDate searchable again for WA


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
