### PR TITLE
CIV-0000 fix deterWithoutHearingRespondent2 show condition

### DIFF
--- a/ccd-definition/CaseEventToFields/DefendantResponse.json
+++ b/ccd-definition/CaseEventToFields/DefendantResponse.json
@@ -620,7 +620,7 @@
     "PageID": "DeterminationWithoutHearing",
     "CaseEventFieldLabel": " ",
     "ShowSummaryChangeOption": "Y",
-    "FieldShowCondition": "addRespondent2 = \"Yes\" AND respondent2SameLegalRepresentative != \"Yes\""
+    "FieldShowCondition": "addRespondent2 = \"Yes\" AND respondent2SameLegalRepresentative != \"Yes\" AND isRespondent1 != \"Yes\""
   },
   {
     "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",


### PR DESCRIPTION
Updated 
    "FieldShowCondition": "addRespondent2 = \"Yes\" AND respondent2SameLegalRepresentative != \"Yes\" AND isRespondent1 != \"Yes\""


So deterWithoutHearingRespondent2 does not show when isRespondent1



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
