### PR TITLE
DTSCCI-2439 Update permissions to view awaiting def response state

### DIFF
--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-LipVsLr-nonprod.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEvent-LipVsLr-nonprod.json
@@ -103,19 +103,6 @@
   },
   {
     "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
-    "CaseEventID": "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE_SPEC",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "RES-SOL-ONE-SPEC-PROFILE",
-          "RES-SOL-TWO-SPEC-PROFILE"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
     "CaseEventID": "NOTIFY_RESPONDENT1_FOR_CLAIM_CONTINUING_ONLINE_SPEC",
     "AccessControl": [
       {

--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec-R2-CUI.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec-R2-CUI.json
@@ -37,42 +37,6 @@
   },
   {
     "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
-    "CaseEventID": "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE_SPEC",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "CITIZEN-CLAIMANT-PROFILE"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
-    "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE_SPEC",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "CITIZEN-CLAIMANT-PROFILE"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
-    "CaseEventID": "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIM_CONTINUING_ONLINE_SPEC",
-    "AccessControl": [
-      {
-        "UserRoles": [
-          "CITIZEN-CLAIMANT-PROFILE"
-        ],
-        "CRUD": "R"
-      }
-    ]
-  },
-  {
-    "CaseTypeID": "CIVIL${CCD_DEF_VERSION}",
     "CaseEventID": "NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE_FOR_SPEC_CC",
     "AccessControl": [
       {

--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec.json
@@ -73,6 +73,7 @@
           "RES-SOL-ONE-SPEC-PROFILE",
           "RES-SOL-TWO-SPEC-PROFILE",
           "caseworker-civil-admin",
+          "CITIZEN-CLAIMANT-PROFILE",
           "GS_profile"
         ],
         "CRUD": "R"
@@ -95,6 +96,7 @@
           "RES-SOL-ONE-SPEC-PROFILE",
           "RES-SOL-TWO-SPEC-PROFILE",
           "caseworker-civil-admin",
+          "CITIZEN-CLAIMANT-PROFILE",
           "GS_profile"
         ],
         "CRUD": "R"
@@ -117,6 +119,7 @@
           "RES-SOL-ONE-SPEC-PROFILE",
           "RES-SOL-TWO-SPEC-PROFILE",
           "caseworker-civil-admin",
+          "CITIZEN-CLAIMANT-PROFILE",
           "GS_profile"
         ],
         "CRUD": "R"

--- a/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec.json
+++ b/ccd-definition/AuthorisationCaseEvent/AuthorisationCaseEventLRspec.json
@@ -66,6 +66,16 @@
           "caseworker-civil-systemupdate"
         ],
         "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "APP-SOL-SPEC-PROFILE",
+          "RES-SOL-ONE-SPEC-PROFILE",
+          "RES-SOL-TWO-SPEC-PROFILE",
+          "caseworker-civil-admin",
+          "GS_profile"
+        ],
+        "CRUD": "R"
       }
     ]
   },
@@ -78,6 +88,16 @@
           "caseworker-civil-systemupdate"
         ],
         "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "APP-SOL-SPEC-PROFILE",
+          "RES-SOL-ONE-SPEC-PROFILE",
+          "RES-SOL-TWO-SPEC-PROFILE",
+          "caseworker-civil-admin",
+          "GS_profile"
+        ],
+        "CRUD": "R"
       }
     ]
   },
@@ -90,6 +110,16 @@
           "caseworker-civil-systemupdate"
         ],
         "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "APP-SOL-SPEC-PROFILE",
+          "RES-SOL-ONE-SPEC-PROFILE",
+          "RES-SOL-TWO-SPEC-PROFILE",
+          "caseworker-civil-admin",
+          "GS_profile"
+        ],
+        "CRUD": "R"
       }
     ]
   },


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSCCI-2439

As the events are hidden in the history the users are not seeing the claim in awaiting def response state,
![image](https://github.com/user-attachments/assets/9131f8a8-d7ab-44ef-9ae8-db72f1374913)

