### PR TITLE
DTSCCI-0000 Remove 'caseworker-civil-solicitor' role for the event link defendant

### DIFF
--- a/ccd-definition/civil/AuthorisationCaseEvent/AuthorisationCaseEvent-testing.json
+++ b/ccd-definition/civil/AuthorisationCaseEvent/AuthorisationCaseEvent-testing.json
@@ -7,7 +7,6 @@
         "UserRoles": [
           "caseworker-civil-systemupdate",
           "caseworker-civil-admin",
-          "caseworker-civil-solicitor",
           "caseworker-civil-staff"
         ],
         "CRUD": "CRU"


### PR DESCRIPTION
Solicitor shoudlnt link the defendant role to the claim