### PR TITLE
DTSCCI-5402: Disable node-fetch HTTPS keep-alive in E2E helper

### DIFF
--- a/e2e/api/restHelper.js
+++ b/e2e/api/restHelper.js
@@ -1,13 +1,17 @@
  
 
 const fetch = require('node-fetch');
+const https = require('https');
 
 const {retry} = require('./retryHelper');
+
+const httpsAgent = new https.Agent({ keepAlive: false });
 
 const request = (url, headers, body, method = 'POST') =>  fetch(url, {
     method: method,
     body: body ? JSON.stringify(body) : undefined,
-    headers: headers
+    headers: headers,
+    agent: url.startsWith('https:') ? httpsAgent : undefined
   });
 
 const retriedRequest = async (url, headers, body, method = 'POST', expectedStatus = 200) => {


### PR DESCRIPTION
Work around Node 24.17.0/node-fetch@2 premature close failures seen in Jenkins

ref: https://github.com/nodejs/node/issues/63989

### JIRA link (if applicable) ###
N/A

### Change description ###

Adds a workaround for Jenkins smoke test failures when calling IDAM `/o/userinfo`.

Jenkins is running Node `24.17.0`, and the failure matches a known `node-fetch@2`/Node 24 transport issue where HTTPS responses can fail during body reads with:
`Invalid response body while trying to fetch ... Premature close`

This change disables HTTPS keep-alive for the shared E2E `node-fetch` helper to avoid reusing sockets affected by the Node/runtime behaviour.

## Changes

- Adds an `https.Agent({ keepAlive: false })` in `e2e/api/restHelper.js`
- Uses that agent for HTTPS requests made through the shared E2E REST helper


## Possible Long-Term Fix
Longer term, we should remove the legacy `node-fetch@2` dependency from the E2E helpers and either:

- migrate `e2e/api/restHelper.js` to native `globalThis.fetch` on supported Node versions, or
- move to a maintained HTTP client with explicit agent/timeout/retry behaviour.

We should also consider pinning Jenkins to an LTS Node runtime

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
