### PR TITLE
DTSCCI-0000: fix pixelmatch require call broken by upgrade

### DIFF
--- a/e2e/helpers/pdfVisualCompareHelper.js
+++ b/e2e/helpers/pdfVisualCompareHelper.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
-const pixelmatch = require('pixelmatch');
+const { default: pixelmatch } = require('pixelmatch');
 const { PNG } = require('pngjs');
 const codeceptjs = require('codeceptjs');
 


### PR DESCRIPTION
### Change description ###

## Summary
- The nightly pipeline was failing PDF visual-comparison tests with `TypeError: pixelmatch is not a function` in `pdfVisualCompareHelper.js`.
- Root cause: #6668 bumped `pixelmatch` from 5.3.0 to 7.2.0. 
- Reproduced locally with a clean install (`rm -rf node_modules && yarn install`) to match CI's fresh-install behaviour 
- Confirmed `1v1_spec_fast_full_defence_test.js` (`viewAndAssertPdf`) passes with the fix

Ran the pdf comparison test in the pipeline and its failing due to the docmosis difference between aat / preview but made it passed the original error: 

<img width="1770" height="792" alt="image" src="https://github.com/user-attachments/assets/1f4ec831-823b-46a3-a288-4c4ae2578ac1" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
