### PR TITLE
OCCC-210: adding expanded states for when you can enter breathing space event

### DIFF
--- a/ccd-definition/civil/CaseEvent/User/UserEvents-nonprod.json
+++ b/ccd-definition/civil/CaseEvent/User/UserEvents-nonprod.json
@@ -5,7 +5,7 @@
     "Name": "Enter Breathing Space",
     "Description": "Enter Breathing Space",
     "DisplayOrder": 7,
-    "PreConditionState(s)": "CASE_PROGRESSION;HEARING_READINESS;PREPARE_FOR_HEARING_CONDUCT_HEARING;DECISION_OUTCOME;All_FINAL_ORDERS_ISSUED",
+    "PreConditionState(s)": "CASE_PROGRESSION;HEARING_READINESS;PREPARE_FOR_HEARING_CONDUCT_HEARING;DECISION_OUTCOME;All_FINAL_ORDERS_ISSUED;AWAITING_APPLICANT_INTENTION;IN_MEDIATION;AWAITING_RESPONDENT_ACKNOWLEDGEMENT",
     "PostConditionState": "*",
     "SecurityClassification": "Public",
     "CallBackURLAboutToStartEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/about-to-start",


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/OCCC-210


### Change description ###
- Adding the expanded states for when you can enter the breathing space event.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
