### PR TITLE
DTSCCI-6135 Fix Civil Admin auth setup and restore nightly test signal

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -294,6 +294,8 @@ withNightlyPipeline(type, product, component) {
           }
           if(playwrightSetupPassed) {
             yarnBuilder.yarn('test:playwright:civil-ccd-nightly:ci')
+          } else {
+            unstable(message: "${STAGE_NAME} did not run: 'Playwright test setup' failed, so no functional tests were executed.")
           }
         } catch (Exception error) {
           if(error instanceof org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) {

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -103,7 +103,6 @@ exports.config = {
     },
   },
   mocha: {
-    bail: true,
     reporterOptions: {
       'codeceptjs-cli-reporter': {
         stdout: '-',

--- a/playwright-e2e/base/base-page.ts
+++ b/playwright-e2e/base/base-page.ts
@@ -1545,7 +1545,15 @@ export default abstract class BasePage {
         assertFirst = false;
 
         if (actionAfterFirstAttempt) {
-          await actionAfterFirstAttempt();
+          try {
+            await actionAfterFirstAttempt();
+          } catch (recoveryError) {
+            // The recovery action failing tells us nothing about why the assertion failed,
+            // and letting it propagate replaces the real error with a misleading one.
+            console.log(`Recovery action failed: ${recoveryError}`);
+            console.log('Reporting the original failure instead');
+            throw error;
+          }
         }
       }
     }


### PR DESCRIPTION
Four fixes to the nightly. See DTSCCI-6135 for the full investigation (builds 1738-1747, 20 builds of Allure trend data, and AM/CWD role-assignment checks on AAT).

## 1. `exui-users.ts` — the actual cause of the red nightly

`Playwright test setup` has failed in **8 of the last 9 nightlies**, always on the same user — Civil Admin — always reporting this:

```
Error: expect(locator).toBeVisible() failed
Locator: locator('label').getByText('Email address', { exact: true })
```

That error is a red herring. The locator is correct — verified against the live AAT IDAM page, which renders `<label for="username"><span class="form-label">Email address</span></label>`.

What actually happens: `civil-admin@mailnesia.com` has **zero AM role assignments** in AAT. Work Allocation tabs are driven by role assignments, so the account lands on `/cases`, never `/work/my-work/list`. The post-login assertion in `manageCaseLogin` fails, the retry's recovery action navigates back to manage-case expecting a login form — which an authenticated session will never show — and the test dies reporting the label error.

Control users confirm it is the account, not the code path:

| user | `wa` | AM role assignments | result |
|---|---|---|---|
| `civil-admin@mailnesia.com` | true | **0** | fails 8/8 |
| `DJ.Amy.Powell@ejudiciary.net` | true | 18 | passes |

The account also lacks the `cwd-user` IDAM role, which reference data documents as being added to every caseworker in CWD by default — so it is not in CWD, and the assignments will not come back on their own.

**Setting `wa: false` costs no coverage.** `user.wa` is referenced in exactly one place in the repo — `login-page.ts:44`, choosing which post-login URL to assert. `/work/my-work/list` appears nowhere else. `CivilAdminLogin()` is defined but never called; `civilAdminUser` is used from API steps. The assertion now matches where the account actually lands.

If we later decide Civil Admin *should* exercise Work Allocation, that needs a CWD record (CFTS ticket for `cwd-admin`, then Staff Data Template upload) plus an ORM refresh — documented in DTSCCI-6135, and a separate piece of work.

## 2. `base-page.ts` — stop the recovery action masking the real failure

In `retryAction`, the recovery action runs *inside* the `catch` that handles an assertion failure. If the recovery throws, its error propagates and replaces the assertion error that actually explains the failure:

```js
} catch (error) {
  if (retries <= 0) throw error;
  ...
  if (actionAfterFirstAttempt) {
    await actionAfterFirstAttempt();   // throws -> replaces `error`
  }
}
```

This is why fix 1 took a week to find: the real failure was a post-login URL assertion, but every build reported "Email address not found" and sent the investigation to the IDAM login page instead of the account's role assignments.

The recovery failing tells us nothing about why the assertion failed, so it is now logged and the original error rethrown. Applies to every `retryAction` caller, not just login.

## 3. `Jenkinsfile_nightly` — a green stage that ran nothing

`Playwright full functional test` is guarded by `if(playwrightSetupPassed)` with no `else`, so when setup fails the stage runs nothing and still reports **SUCCESS**:

```
UNSTABLE  5m   Playwright test setup
SUCCESS   0m   Playwright full functional test     <-- 0 minutes, 0 tests
UNSTABLE  0m   Playwright test teardown
UNSTABLE  86m  Full functional tests
```

All 56 `@civil-ccd-nightly` Playwright spec files have been silently skipped behind a green stage for over a week — which is why a 100% reproducible single-user failure went unnoticed. Now marked unstable with an explicit message.

## 4. `codecept.conf.js` — drop `bail: true`

With `run-workers --suites 15`, mocha's `bail` makes each worker abandon its remaining suites on first failure. Allure totals show the cost as tests that never execute:

| build | failures | tests executed |
|---|---|---|
| clean run | 0 | 245 |
| 1744 | 1 broken | 238 |
| 1745 | 3 failed | 202 |
| 1743 | 3 failed, 5 broken | 194 |
| 1746 | 10 failed | 172 |

Roughly 7 tests lost per failure. Removing `bail` gives full coverage per run and complete flake data.

## Notes

- Fixes 1 and 3 together should make the Playwright suite run for the first time in over a week. We have no current signal on whether those 56 specs pass, so expect new failures to surface — that is the suite reporting honestly, not a regression from this PR.
- Fix 2 is a behaviour change for every `retryAction` caller: where a recovery action previously threw its own error, you now get the original assertion error and one fewer retry attempt. Tests that were passing are unaffected; failing tests should get more accurate messages.
- I considered also making the login recovery clear cookies so the retry could genuinely re-attempt login, and left it out: `exuiLogin` seeds IDAM and ExUI consent cookies before navigating, and clearing them in recovery risks reintroducing banner handling for the users that currently pass. With fix 2 the true error surfaces immediately, which is the outcome that matters.
- I did not add retries to the setup projects: `exui-users-auth-setup` has no explicit `retries` key so it already inherits `PLAYWRIGHT_RETRIES` (default 1), and it failed anyway — the failure was deterministic, not flaky.
