### PR TITLE
DTSCCI-6148: negative intrest rates bugfix

### DIFF
--- a/ccd-definition/civil/CaseEventToFields/CreateClaimLRspec.json
+++ b/ccd-definition/civil/CaseEventToFields/CreateClaimLRspec.json
@@ -750,7 +750,8 @@
     "PageDisplayOrder": 34,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "PageShowCondition": "interestClaimOptions = \"SAME_RATE_INTEREST\" AND claimInterest = \"Yes\""
+    "PageShowCondition": "interestClaimOptions = \"SAME_RATE_INTEREST\" AND claimInterest = \"Yes\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -761,7 +762,8 @@
     "PageID": "SameRateInterestSelection",
     "PageDisplayOrder": 34,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "Y"
+    "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -772,7 +774,8 @@
     "PageID": "SameRateInterestSelection",
     "PageDisplayOrder": 34,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "N"
+    "ShowSummaryChangeOption": "N",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -784,7 +787,8 @@
     "PageDisplayOrder": 35,
     "PageColumnNumber": 1,
     "ShowSummaryChangeOption": "Y",
-    "PageShowCondition": "interestClaimOptions = \"BREAK_DOWN_INTEREST\" AND claimInterest = \"Yes\""
+    "PageShowCondition": "interestClaimOptions = \"BREAK_DOWN_INTEREST\" AND claimInterest = \"Yes\"",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -795,7 +799,8 @@
     "PageID": "BreakDownInterest",
     "PageDisplayOrder": 35,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "Y"
+    "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",
@@ -806,7 +811,8 @@
     "PageID": "BreakDownInterest",
     "PageDisplayOrder": 35,
     "PageColumnNumber": 1,
-    "ShowSummaryChangeOption": "Y"
+    "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${CCD_DEF_CASE_SERVICE_BASE_URL}/cases/callbacks/mid/ValidateClaimInterestDate"
   },
   {
     "CaseTypeID": "CIVIL",


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSCCI-6148](https://tools.hmcts.net/jira/browse/DTSCCI-6148)

Related: [civil-service PR #8198](https://github.com/hmcts/civil-service/pull/8198) (DTSCCI-6043)

### Change description ###

Adds mid-event callbacks on the create-claim SPEC interest rate / breakdown pages so negative interest values are validated when the user clicks Continue on those pages (instead of only later on the interest-from-date page).

Previously `SameRateInterestSelection` and `BreakDownInterest` had no `CallBackURLMidEvent`, so civil-service was never invoked there.

Both pages now call:
`/cases/callbacks/mid/ValidateClaimInterestDate`

That reuses the validation added in civil-service PR #8198 (`Enter a positive interest rate` / `Enter a positive interest amount`).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

### Test plan
- [ ] Deploy with `civilServicePr:8198`
- [ ] Create claim SPEC → claim interest → same rate → enter a negative custom rate → Continue
- [ ] Confirm error is shown on `SameRateInterestSelection` and user cannot proceed
- [ ] Enter a valid positive rate and confirm journey continues
- [ ] Repeat for breakdown interest with a negative amount